### PR TITLE
Fix container id retrieval and allow skipping certificate validation

### DIFF
--- a/src/apps/Synapse.Worker/Configuration/ApplicationOptions.cs
+++ b/src/apps/Synapse.Worker/Configuration/ApplicationOptions.cs
@@ -8,6 +8,22 @@
     {
 
         /// <summary>
+        /// Initializes a new <see cref="ApplicationOptions"/>
+        /// </summary>
+        public ApplicationOptions()
+        {
+            var env = EnvironmentVariables.SkipCertificateValidation.Value;
+            if (!string.IsNullOrWhiteSpace(env)
+                && bool.TryParse(env, out var skipCertificateValidation))
+                this.SkipCertificateValidation = skipCertificateValidation;
+        }
+
+        /// <summary>
+        /// Gets/sets a boolean indicating whether or not to skip certificate validation when performing http requests
+        /// </summary>
+        public virtual bool SkipCertificateValidation { get; set; }
+
+        /// <summary>
         /// Gets/sets the object used to configure the Synapse APIs clients used to by the application
         /// </summary>
         public virtual ApiClientConfigurationCollection Api { get; set; } = new();

--- a/src/core/Synapse.Application/Configuration/SynapseApplicationOptions.cs
+++ b/src/core/Synapse.Application/Configuration/SynapseApplicationOptions.cs
@@ -25,6 +25,22 @@ namespace Synapse.Application.Configuration
     {
 
         /// <summary>
+        /// Initializes a new <see cref="SynapseApplicationOptions"/>
+        /// </summary>
+        public SynapseApplicationOptions()
+        {
+            var env = EnvironmentVariables.SkipCertificateValidation.Value;
+            if (!string.IsNullOrWhiteSpace(env)
+                && bool.TryParse(env, out var skipCertificateValidation))
+                this.SkipCertificateValidation = skipCertificateValidation;
+        }
+
+        /// <summary>
+        /// Gets/sets a boolean indicating whether or not to skip certificate validation when performing http requests
+        /// </summary>
+        public virtual bool SkipCertificateValidation { get; set; }
+
+        /// <summary>
         /// Gets/sets the options used to configure the application's cloud eventss
         /// </summary>
         public virtual CloudEventOptions CloudEvents { get; set; } = new();

--- a/src/core/Synapse.Integration/EnvironmentVariables.cs
+++ b/src/core/Synapse.Integration/EnvironmentVariables.cs
@@ -32,6 +32,24 @@ namespace Synapse
         public const string Prefix = "SYNAPSE_";
 
         /// <summary>
+        /// Exposes constants about the environment variable used to skip certificate validation
+        /// </summary>
+        public static class SkipCertificateValidation
+        {
+
+            /// <summary>
+            /// Gets the name of the environment variable used to skip certificate validation
+            /// </summary>
+            public const string Name = Prefix + "SKIP_CERTIFICATE_VALIDATION";
+
+            /// <summary>
+            /// Gets the value of the environment variable used to skip certificate validation
+            /// </summary>
+            public static string Value = Environment.GetEnvironmentVariable(Name);
+
+        }
+
+        /// <summary>
         /// Exposes constants about <see cref="CloudEvent"/>-related environment variables
         /// </summary>
         public static class CloudEvents


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the way the server's container id was retrieved, which seemed to not work as expected on some systems
- Added options to configure the skipping of certificate validation, which was required in some specific, exotic use-cases