### PR TITLE
Fixed the NativeInstallCommand to use its own version when downloading the server binary files

### DIFF
--- a/src/apps/Synapse.Cli/Commands/Systems/Installs/NativeInstallCommand.cs
+++ b/src/apps/Synapse.Cli/Commands/Systems/Installs/NativeInstallCommand.cs
@@ -100,7 +100,7 @@ namespace Synapse.Cli.Commands.Systems.Installs
                         {
                             AutoStart = false
                         });
-                        await this.HttpClient.DownloadAsync($"https://github.com/serverlessworkflow/synapse/releases/download/0.1.0/synapse-{target}", packageStream, task);
+                        await this.HttpClient.DownloadAsync($"https://github.com/serverlessworkflow/synapse/releases/download/{typeof(NativeInstallCommand).Assembly.GetName()!.Version!.ToString(3)}/synapse-{target}", packageStream, task);
                     });
                 });
             AnsiConsole.Status()


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Fixed the NativeInstallCommand to use its own version when downloading the server binary files