### PR TITLE
fix(Runtime.Native): Fixed the NativeRuntimeHost to properly start worker process by forwarding the SYNAPSE_SKIP_CERTIFICATE_VALIDATION environment variable

### DIFF
--- a/src/apps/Synapse.Worker/Services/WorkflowRuntime.cs
+++ b/src/apps/Synapse.Worker/Services/WorkflowRuntime.cs
@@ -241,9 +241,6 @@ namespace Synapse.Worker.Services
         {
             if (signal == null)
                 return;
-
-            Console.WriteLine($"Signal of type '{signal.Type}' received: {JsonConvert.SerializeObject(signal.Data)}"); //todo: remove
-
             try
             {
                 switch (signal.Type)
@@ -252,9 +249,7 @@ namespace Synapse.Worker.Services
                         var correlationContext = signal.Data!.ToObject<V1CorrelationContext>();
                         foreach (var e in correlationContext.PendingEvents)
                         {
-                            Console.WriteLine($"SPUBLISHING INTEGRATION EVENT"); //todo: remove
                             this.IntegrationEventBus.InboundStream.OnNext(e.ToCloudEvent());
-                            Console.WriteLine($"INTEGRATION EVENT PUBLISHED"); //todo: remove
                         }
                         break;
                     case V1RuntimeSignalType.Suspend:

--- a/src/runtime/Synapse.Runtime.Native/Properties/launchSettings.json
+++ b/src/runtime/Synapse.Runtime.Native/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "Synapse.Runtime.Native": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/src/runtime/Synapse.Runtime.Native/Services/NativeRuntimeHost.cs
+++ b/src/runtime/Synapse.Runtime.Native/Services/NativeRuntimeHost.cs
@@ -18,9 +18,11 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Synapse.Application.Configuration;
 using Synapse.Application.Services;
 using Synapse.Domain.Models;
 using Synapse.Runtime.Docker.Configuration;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO.Compression;
@@ -42,12 +44,15 @@ namespace Synapse.Runtime.Services
         /// <param name="loggerFactory">The service used to create <see cref="ILogger"/>s</param>
         /// <param name="environment">The current <see cref="IHostEnvironment"/></param>
         /// <param name="httpClientFactory">The service used to create <see cref="System.Net.Http.HttpClient"/>s</param>
+        /// <param name="applicationOptions">The service used to access the current <see cref="SynapseApplicationOptions"/></param>
         /// <param name="options">The service used to access the current <see cref="NativeRuntimeOptions"/></param>
-        public NativeRuntimeHost(ILoggerFactory loggerFactory, IHostEnvironment environment, IHttpClientFactory httpClientFactory, IOptions<NativeRuntimeOptions> options)
+        public NativeRuntimeHost(ILoggerFactory loggerFactory, IHostEnvironment environment, IHttpClientFactory httpClientFactory, 
+            IOptions<SynapseApplicationOptions> applicationOptions, IOptions<NativeRuntimeOptions> options)
             : base(loggerFactory)
         {
             this.Environment = environment;
             this.HttpClient = httpClientFactory.CreateClient();
+            this.ApplicationOptions = applicationOptions.Value;
             this.Options = options.Value;
         }
 
@@ -60,6 +65,11 @@ namespace Synapse.Runtime.Services
         /// Gets the <see cref="System.Net.Http.HttpClient"/> used to perform HTTP requests
         /// </summary>
         protected HttpClient HttpClient { get; }
+
+        /// <summary>
+        /// Gets the current <see cref="SynapseApplicationOptions"/>
+        /// </summary>
+        protected SynapseApplicationOptions ApplicationOptions { get; }
 
         /// <summary>
         /// Gets the current <see cref="NativeRuntimeOptions"/>
@@ -131,6 +141,8 @@ namespace Synapse.Runtime.Services
             };
             startInfo.Environment.Add(EnvironmentVariables.Api.HostName.Name, EnvironmentVariables.Api.HostName.Value!); //todo: instead, fetch values from options
             startInfo.Environment.Add(EnvironmentVariables.Runtime.WorkflowInstanceId.Name, workflowInstance.Id.ToString());
+            if (this.ApplicationOptions.SkipCertificateValidation)
+                startInfo.Environment.Add(EnvironmentVariables.SkipCertificateValidation.Name, "true");
             var process = new Process()
             {
                 StartInfo = startInfo,


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Properly start worker process when using native runtime host by forwarding the SYNAPSE_SKIP_CERTIFICATE_VALIDATION environment variable