### PR TITLE
Fixed the V1EventMappingConfiguration by setting the mapping for the SpecVersion property when converting from a CloudEvent

### DIFF
--- a/src/core/Synapse.Application/Mapping/Configuration/V1EventMappingConfiguration.cs
+++ b/src/core/Synapse.Application/Mapping/Configuration/V1EventMappingConfiguration.cs
@@ -27,7 +27,7 @@ namespace Synapse.Application.Mapping.Configuration
 
         void IMappingConfiguration<CloudEvent, Integration.Models.V1Event>.Configure(IMappingExpression<CloudEvent, Integration.Models.V1Event> mapping)
         {
-            
+            mapping.ForMember(e => e.SpecVersion, options => options.MapFrom(ce => ce.SpecVersion.VersionId));
         }
 
         void IMappingConfiguration<V1Event, Integration.Models.V1Event>.Configure(IMappingExpression<V1Event, Integration.Models.V1Event> mapping)


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Fixed the V1EventMappingConfiguration by setting the mapping for the SpecVersion property when converting from a CloudEvent. 

Without that, the SpecVersion would always be equal to `CloudNative.CloudEvents.CloudEventsSpecVersion`