### PR TITLE
Enable dashboard live reload and debugging

### DIFF
--- a/src/apps/Synapse.Server/Program.cs
+++ b/src/apps/Synapse.Server/Program.cs
@@ -53,7 +53,9 @@ builder.Services.AddSynapse(builder.Configuration, synapse =>
 });
 builder.Services.AddJQExpressionEvaluator();
 using var app = builder.Build();
-if (!app.Environment.IsDevelopment())
+if (app.Environment.IsDevelopment())
+    app.UseWebAssemblyDebugging();
+else
     app.UseExceptionHandler("/error");
 app.UseCloudEvents();
 app.UseBlazorFrameworkFiles();

--- a/src/apps/Synapse.Server/Properties/launchSettings.json
+++ b/src/apps/Synapse.Server/Properties/launchSettings.json
@@ -17,6 +17,7 @@
         "SYNAPSE_PERSISTENCE_READMODEL_DEFAULT_REPOSITORY": "MongoDB",
         "SYNAPSE_API_HOSTNAME": "localhost"
       },
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "applicationUrl": "http://localhost:42286",
       "dotnetRunMessages": true
     },

--- a/src/dashboard/Synapse.Dashboard/Program.cs
+++ b/src/dashboard/Synapse.Dashboard/Program.cs
@@ -30,16 +30,17 @@ using Synapse.Dashboard;
 using Synapse.Dashboard.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
+var baseAddress = builder.HostEnvironment.BaseAddress;
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
-builder.Services.AddScoped(provider => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
-builder.Services.AddSynapseRestApiClient(http => http.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress));
+builder.Services.AddScoped(provider => new HttpClient { BaseAddress = new Uri(baseAddress) });
+builder.Services.AddSynapseRestApiClient(http => http.BaseAddress = new Uri(baseAddress));
 builder.Services.AddServerlessWorkflow();
 builder.Services.AddPluralizer();
 builder.Services.AddSingleton<IODataClient>(new ODataClient(new ODataClientSettings()
 {
-    BaseUri = new($"http://localhost:42286/api/odata"),
+    BaseUri = new($"{baseAddress}api/odata"),
     PayloadFormat = ODataPayloadFormat.Json
 }));
 builder.Services.AddScoped<ILayoutService, LayoutService>();
@@ -59,7 +60,7 @@ builder.Services.AddFlux(flux =>
 builder.Services.AddSingleton(provider =>
 {
     return new HubConnectionBuilder()
-        .WithUrl($"http://localhost:42286/api/ws")
+        .WithUrl($"{baseAddress}api/ws")
         .WithAutomaticReconnect()
         .AddNewtonsoftJsonProtocol(options =>
         {

--- a/src/dashboard/Synapse.Dashboard/Properties/launchSettings.json
+++ b/src/dashboard/Synapse.Dashboard/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
-      "applicationUrl": "http://localhost:5218",
+      "applicationUrl": "http://localhost:42286",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Use builder.HostEnvironment.BaseAddress for configuring api clients, thus avoiding additional configuration needs as well as CORS settings
- Configures the server to allow live-reload and debugging of the Dashboard