### PR TITLE
fix(Dashboard): Prevented to reset start input value with each OnParametersSetAsync

### DIFF
--- a/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowToolbar/WorkflowToolbar.razor
+++ b/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowToolbar/WorkflowToolbar.razor
@@ -78,6 +78,7 @@
 @code {
     [Parameter]
     public V1Workflow Workflow { get; set; } = null!;
+    protected V1Workflow workflow { get; set; } = null!;
 
     protected Modal errorModal = null!;
     protected Modal workflowInputModal = null!;
@@ -89,10 +90,9 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        if(this.workflowInputEditor != null)
-            await this.workflowInputEditor.SetValue("{}");
-        if (this.Workflow != null)
+        if (this.Workflow != null && this.workflow != this.Workflow)
         {
+            this.workflow = this.Workflow;
             await this.LoadDataInputSchemaAsync();
         }
     }
@@ -154,6 +154,7 @@
         }
         await this.workflowInputModal.HideAsync();
         this.inputValidationErrors = null;
+        this.StateHasChanged();
         if(this.workflowInputEditor != null)
             await this.workflowInputEditor.SetValue("{}");
         var inputData = await this.JsonSerializer.DeserializeAsync<DynamicObject>(json);


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevented the value of the input in the 'start workflow' modal to be overriden each time `OnParametersSetAsync` was called.

Closes serverlessworkflow#76