### PR TITLE
Fixed the WorkflowRuntime by correctly checking if a transition has been defined. Before, the worker only checked if the 'Transition' object was defined

### DIFF
--- a/src/apps/Synapse.Worker/Services/Processors/OperationStateProcessor.cs
+++ b/src/apps/Synapse.Worker/Services/Processors/OperationStateProcessor.cs
@@ -119,6 +119,8 @@ namespace Synapse.Worker.Services.Processors
                 .Where(a => a.Type == V1WorkflowActivityType.Action && a.Status == V1WorkflowActivityStatus.Completed)
                 .OrderBy(a => a.ExecutedAt))
             {
+                if (activity.Output == null)
+                    continue;
                 if (!activity.Metadata.TryGetValue(V1WorkflowActivityMetadata.Action, out var actionName))
                     throw new ArgumentException($"The specified activity '{activity.Id}' is missing the required metadata field '{V1WorkflowActivityMetadata.Action}'");
                 if (!this.State.TryGetAction(actionName, out var action))

--- a/src/apps/Synapse.Worker/Services/WorkflowRuntime.cs
+++ b/src/apps/Synapse.Worker/Services/WorkflowRuntime.cs
@@ -323,7 +323,7 @@ namespace Synapse.Worker.Services
             else
             {
                 if (processor.State.Transition != null
-                    && string.IsNullOrWhiteSpace(processor.State.TransitionToStateName))
+                    || !string.IsNullOrWhiteSpace(processor.State.TransitionToStateName))
                     await this.Context.Workflow.CreateActivityAsync(V1WorkflowActivityType.Transition, e.Output!.ToObject()!, metadata, null, this.CancellationToken);
                 else if (processor.State.End != null
                     || processor.State.IsEnd)


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixed the WorkflowRuntime by correctly checking if a transition has been defined. Before, the worker only checked if the 'Transition' object was defined
- Fixed the OperationStateProcessor by ignoring outputless activities when aggregating child action outputs