### PR TITLE
Prevented "NotSupportedException" when trying to find a graph node for an activity type that is not represented

### DIFF
--- a/src/dashboard/Synapse.Dashboard/Extensions/GraphExtensions.cs
+++ b/src/dashboard/Synapse.Dashboard/Extensions/GraphExtensions.cs
@@ -67,7 +67,7 @@ namespace Synapse.Dashboard
         public static IWorkflowNodeViewModel? GetNodeFor(this IGraphViewModel graph, V1WorkflowActivity activity)
         {
             if (activity == null)
-                throw new ArgumentNullException(nameof(activity));
+                return null;
             switch (activity.Type)
             {
                 case V1WorkflowActivityType.Action:
@@ -95,7 +95,7 @@ namespace Synapse.Dashboard
                 case V1WorkflowActivityType.SubFlow:
                     throw new NotImplementedException(); //todo
                 default:
-                    throw new NotSupportedException($"The specified {nameof(V1WorkflowActivityType)} '{activity.Type}' is not supported");
+                    return null;
             }
         }
 


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
Closes serverlessworkflow#90