### PR TITLE
Fixed the WorkflowRuntimeContext by renaming the CONTEXT runtime expression variable into `WORKFLOW`

### DIFF
--- a/src/apps/Synapse.Worker/Services/WorkflowRuntimeContext.cs
+++ b/src/apps/Synapse.Worker/Services/WorkflowRuntimeContext.cs
@@ -175,7 +175,7 @@ namespace Synapse.Worker.Services
         {
             var args = new Dictionary<string, object>
             {
-                { "CONTEXT", await this.BuildRuntimeExpressionContextArgumentAsync(cancellationToken) },
+                { "WORKFLOW", await this.BuildWorkflowExpressionContextArgumentAsync(cancellationToken) },
                 { "CONST", await this.BuildRuntimeExpressionConstantsArgumentAsync(cancellationToken) },
                 { "SECRETS", await this.BuildRuntimeExpressionSecretsArgumentAsync(cancellationToken) }
             };
@@ -183,20 +183,20 @@ namespace Synapse.Worker.Services
         }
 
         /// <summary>
-        /// Builds the runtime expression '$CONTEXT' argument object
+        /// Builds the runtime expression '$WORKFLOW' argument object
         /// </summary>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
-        /// <returns>The runtime expression '$CONTEXT' argument object</returns>
-        protected virtual async Task<object> BuildRuntimeExpressionContextArgumentAsync(CancellationToken cancellationToken)
+        /// <returns>The runtime expression '$WORKFLOW' argument object</returns>
+        protected virtual async Task<object> BuildWorkflowExpressionContextArgumentAsync(CancellationToken cancellationToken)
         {
-            return new
+            return await Task.FromResult(new
             {
                 workflow = new
                 {
                     id = this.Workflow.Definition.GetUniqueIdentifier(),
                     instanceId = this.Workflow.Instance.Id
                 }
-            }; //todo
+            });
         }
 
         /// <summary>
@@ -206,10 +206,10 @@ namespace Synapse.Worker.Services
         /// <returns>The runtime expression '$CONST' argument object</returns>
         protected virtual async Task<object> BuildRuntimeExpressionConstantsArgumentAsync(CancellationToken cancellationToken)
         {
-            var constants = this.Workflow.Definition.Constants?.ToObject(); //todo
+            var constants = this.Workflow.Definition.Constants?.ToObject();
             if (constants == null)
                 constants = new();
-            return constants;
+            return await Task.FromResult(constants);
         }
 
         /// <summary>


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Fixed the WorkflowRuntimeContext by renaming the CONTEXT runtime expression variable into `WORKFLOW`, as defined by the SW spec