### PR TITLE
fix(Dashboard): Display active workflow instances only in workflow view

### DIFF
--- a/src/dashboard/Synapse.Dashboard/Pages/Workflows/View.razor
+++ b/src/dashboard/Synapse.Dashboard/Pages/Workflows/View.razor
@@ -160,7 +160,7 @@ else
         this.workflowInstanceSubscription = this.workflowInstanceFeature
             .Subscribe(instances =>
             {
-                this.instances = instances;
+                this.instances = instances.Where(instance => instance.WorkflowId == this.WorkflowId).ToList();
                 this.UpdateActivities();
             });
         this.workflowActivitySubscription = this.workflowActivityFeature


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
Only displays instances for the active workflow definition in the workflow view.
