### PR TITLE
Fixed the V1ArchiveWorkflowCommandHandler by archiving projections instead of write models, and adding archiving of persisted events thanks to the IEventStore service, if present

### DIFF
--- a/src/core/Synapse.Application/Synapse.Application.csproj
+++ b/src/core/Synapse.Application/Synapse.Application.csproj
@@ -32,8 +32,10 @@
 	<PackageReference Include="Microsoft.OData.ModelBuilder" Version="1.0.8" />
 	<PackageReference Include="Neuroglia.AspNetCore.JsonPatch" Version="2.0.1.63" />
 	<PackageReference Include="Neuroglia.Data.DistributedCache" Version="2.0.1.63" />
+	<PackageReference Include="Neuroglia.Data.EventSourcing" Version="2.0.1.63" />
 	<PackageReference Include="Neuroglia.Mediation.FluentValidation" Version="2.0.1.63" />
 	<PackageReference Include="ServerlessWorkflow.Sdk" Version="0.8.1.5" />
+	<PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Fixed the V1ArchiveWorkflowCommandHandler by archiving projections instead of write models, and adding archiving of persisted events thanks to the IEventStore service, if present