### PR TITLE
Fixed the V1WorkflowActivityDomainEventHandler to properly update parent V1WorkflowInstances upon change

### DIFF
--- a/src/apps/Synapse.Worker/Extensions/HttpClientExtensions.cs
+++ b/src/apps/Synapse.Worker/Extensions/HttpClientExtensions.cs
@@ -16,6 +16,7 @@
  */
 
 using Microsoft.Extensions.DependencyInjection;
+using Neuroglia.Data.Expressions;
 using System.Net.Http.Headers;
 using System.Text;
 
@@ -40,12 +41,16 @@ namespace Synapse.Worker
         {
             if (authentication == null)
                 return;
+            var evaluator = serviceProvider.GetRequiredService<IExpressionEvaluator>();
             var scheme = null as string;
             var value = null as string;
             switch (authentication.Properties)
             {
                 case BasicAuthenticationProperties basic:
                     scheme = "Basic";
+                    var username = basic.Username;
+                    var password = basic.Password;
+
                     value = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{basic.Username}:{basic.Password}"));
                     break;
                 case BearerAuthenticationProperties bearer:

--- a/src/core/Synapse.Application/Events/Domain/v1/V1WorkflowActivityDomainEventHandler.cs
+++ b/src/core/Synapse.Application/Events/Domain/v1/V1WorkflowActivityDomainEventHandler.cs
@@ -168,11 +168,19 @@ namespace Synapse.Application.Events.Domain
         protected virtual async ValueTask UpdateParentWorkflowInstanceAsync(Integration.Models.V1WorkflowActivity activity, CancellationToken cancellationToken)
         {
             var instance = await this.WorkflowInstances.FindAsync(activity.WorkflowInstanceId, cancellationToken);
-            var existingActivity = instance.Activities.FirstOrDefault(a => a.Id == activity.Id);
+            Integration.Models.V1WorkflowActivity existingActivity = instance.Activities.FirstOrDefault(a => a.Id == activity.Id)!;
             if (existingActivity == null)
+            {
                 instance.Activities.Add(activity);
+            } 
             else
-                this.Mapper.Map(activity, existingActivity);
+            {
+                var list = instance.Activities.ToList();
+                var index = list.IndexOf(existingActivity);
+                existingActivity = this.Mapper.Map(activity, existingActivity);
+                list[index] = existingActivity;
+                instance.Activities = list;
+            }
             await this.WorkflowInstances.UpdateAsync(instance, cancellationToken);
             await this.WorkflowInstances.SaveChangesAsync(cancellationToken);
         }

--- a/src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB/Services/DynamicObjectSerializer.cs
+++ b/src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB/Services/DynamicObjectSerializer.cs
@@ -16,6 +16,7 @@
  */
 
 using MongoDB.Bson;
+using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
 using Neuroglia.Serialization;
@@ -34,7 +35,7 @@ namespace Synapse.Plugins.Persistence.MongoDB.Services
         /// <inheritdoc/>
         public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, DynamicObject value)
         {
-            var jsonDocument = JsonConvert.SerializeObject(value);
+            var jsonDocument = Newtonsoft.Json.JsonConvert.SerializeObject(value);
             var bsonDocument = value == null ? null : BsonSerializer.Deserialize<BsonDocument>(jsonDocument);
             var serializer = new BsonValueCSharpNullSerializer<BsonDocument>(BsonSerializer.LookupSerializer<BsonDocument>());
             serializer.Serialize(context, bsonDocument!);
@@ -48,8 +49,8 @@ namespace Synapse.Plugins.Persistence.MongoDB.Services
             var bsonDocument = document.ToBsonDocument();
             if (bsonDocument == null)
                 return null!;
-            var result = bsonDocument.ToJson();
-            var expando = JsonConvert.DeserializeObject<System.Dynamic.ExpandoObject>(result)!;
+            var result = bsonDocument.ToJson(new() { OutputMode = JsonOutputMode.RelaxedExtendedJson });
+            var expando = Newtonsoft.Json.JsonConvert.DeserializeObject<System.Dynamic.ExpandoObject>(result)!;
             return DynamicObject.FromObject(expando)!;
         }
 


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the V1WorkflowActivityDomainEventHandler to properly update parent V1WorkflowInstances upon change
- Fixes the DynamicObjectSerializer by using the RelaxedExtendedJson JsonOutputMode when converting a BSON document to JSON