### PR TITLE
Fixed the default Kubernetes runtime options to always pull the worker image of the current assembly version, instead of latest if not present

### DIFF
--- a/src/apis/management/Synapse.Apis.Management.Core/Synapse.Apis.Management.Core.csproj
+++ b/src/apis/management/Synapse.Apis.Management.Core/Synapse.Apis.Management.Core.csproj
@@ -5,7 +5,7 @@
 	<RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Core", ""))</RootNamespace>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
-	<VersionPrefix>0.1.12</VersionPrefix>
+	<VersionPrefix>0.1.14</VersionPrefix>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/management/Synapse.Apis.Management.Grpc.Client/Synapse.Apis.Management.Grpc.Client.csproj
+++ b/src/apis/management/Synapse.Apis.Management.Grpc.Client/Synapse.Apis.Management.Grpc.Client.csproj
@@ -5,7 +5,7 @@
 	<RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Client", ""))</RootNamespace>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
-	<VersionPrefix>0.1.12</VersionPrefix>
+	<VersionPrefix>0.1.14</VersionPrefix>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/management/Synapse.Apis.Management.Grpc/Synapse.Apis.Management.Grpc.csproj
+++ b/src/apis/management/Synapse.Apis.Management.Grpc/Synapse.Apis.Management.Grpc.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<VersionPrefix>0.1.12</VersionPrefix>
+		<VersionPrefix>0.1.14</VersionPrefix>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Authors>The Synapse Authors</Authors>
 		<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/management/Synapse.Apis.Management.Http.Client/Synapse.Apis.Management.Http.Client.csproj
+++ b/src/apis/management/Synapse.Apis.Management.Http.Client/Synapse.Apis.Management.Http.Client.csproj
@@ -5,7 +5,7 @@
 	<RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Client", ""))</RootNamespace>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
-	<VersionPrefix>0.1.12</VersionPrefix>
+	<VersionPrefix>0.1.14</VersionPrefix>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/management/Synapse.Apis.Management.Http/Synapse.Apis.Management.Http.csproj
+++ b/src/apis/management/Synapse.Apis.Management.Http/Synapse.Apis.Management.Http.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<VersionPrefix>0.1.12</VersionPrefix>
+		<VersionPrefix>0.1.14</VersionPrefix>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Authors>The Synapse Authors</Authors>
 		<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/management/Synapse.Apis.Management.Ipc.Client/Synapse.Apis.Management.Ipc.Client.csproj
+++ b/src/apis/management/Synapse.Apis.Management.Ipc.Client/Synapse.Apis.Management.Ipc.Client.csproj
@@ -5,7 +5,7 @@
 	<RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Client", ""))</RootNamespace>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
-	<VersionPrefix>0.1.12</VersionPrefix>
+	<VersionPrefix>0.1.14</VersionPrefix>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/monitoring/Synapse.Apis.Monitoring.Core/Synapse.Apis.Monitoring.Core.csproj
+++ b/src/apis/monitoring/Synapse.Apis.Monitoring.Core/Synapse.Apis.Monitoring.Core.csproj
@@ -5,7 +5,7 @@
 	<RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Core", ""))</RootNamespace>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
-	<VersionPrefix>0.1.12</VersionPrefix>
+	<VersionPrefix>0.1.14</VersionPrefix>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/monitoring/Synapse.Apis.Monitoring.WebSocket/Synapse.Apis.Monitoring.WebSocket.csproj
+++ b/src/apis/monitoring/Synapse.Apis.Monitoring.WebSocket/Synapse.Apis.Monitoring.WebSocket.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<VersionPrefix>0.1.12</VersionPrefix>
+		<VersionPrefix>0.1.14</VersionPrefix>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Authors>The Synapse Authors</Authors>
 		<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/runtime/Synapse.Apis.Runtime.Core/Synapse.Apis.Runtime.Core.csproj
+++ b/src/apis/runtime/Synapse.Apis.Runtime.Core/Synapse.Apis.Runtime.Core.csproj
@@ -5,7 +5,7 @@
 	<RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Core", ""))</RootNamespace>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
-	<VersionPrefix>0.1.12</VersionPrefix>
+	<VersionPrefix>0.1.14</VersionPrefix>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/runtime/Synapse.Apis.Runtime.Grpc.Client/Synapse.Apis.Runtime.Grpc.Client.csproj
+++ b/src/apis/runtime/Synapse.Apis.Runtime.Grpc.Client/Synapse.Apis.Runtime.Grpc.Client.csproj
@@ -5,7 +5,7 @@
 	<RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Client", ""))</RootNamespace>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
-	<VersionPrefix>0.1.12</VersionPrefix>
+	<VersionPrefix>0.1.14</VersionPrefix>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/runtime/Synapse.Apis.Runtime.Grpc/Synapse.Apis.Runtime.Grpc.csproj
+++ b/src/apis/runtime/Synapse.Apis.Runtime.Grpc/Synapse.Apis.Runtime.Grpc.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<VersionPrefix>0.1.12</VersionPrefix>
+		<VersionPrefix>0.1.14</VersionPrefix>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Authors>The Synapse Authors</Authors>
 		<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/runtime/Synapse.Apis.Runtime.Ipc.Client/Synapse.Apis.Runtime.Ipc.Client.csproj
+++ b/src/apis/runtime/Synapse.Apis.Runtime.Ipc.Client/Synapse.Apis.Runtime.Ipc.Client.csproj
@@ -5,7 +5,7 @@
 	<RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Client", ""))</RootNamespace>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
-	<VersionPrefix>0.1.12</VersionPrefix>
+	<VersionPrefix>0.1.14</VersionPrefix>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/apps/Synapse.Cli/Synapse.Cli.csproj
+++ b/src/apps/Synapse.Cli/Synapse.Cli.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<OutputType>Exe</OutputType>
-	<VersionPrefix>0.1.12</VersionPrefix>
+	<VersionPrefix>0.1.14</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/apps/Synapse.Server/Synapse.Server.csproj
+++ b/src/apps/Synapse.Server/Synapse.Server.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<VersionPrefix>0.1.12</VersionPrefix>
+	<VersionPrefix>0.1.14</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/apps/Synapse.Worker/Synapse.Worker.csproj
+++ b/src/apps/Synapse.Worker/Synapse.Worker.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<OutputType>Exe</OutputType>
-	<VersionPrefix>0.1.12</VersionPrefix>
+	<VersionPrefix>0.1.14</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/core/Synapse.Application/Synapse.Application.csproj
+++ b/src/core/Synapse.Application/Synapse.Application.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	  <VersionPrefix>0.1.12</VersionPrefix>
+	  <VersionPrefix>0.1.14</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/core/Synapse.Domain/Synapse.Domain.csproj
+++ b/src/core/Synapse.Domain/Synapse.Domain.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	  <VersionPrefix>0.1.12</VersionPrefix>
+	  <VersionPrefix>0.1.14</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/core/Synapse.Infrastructure/Synapse.Infrastructure.csproj
+++ b/src/core/Synapse.Infrastructure/Synapse.Infrastructure.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<VersionPrefix>0.1.12</VersionPrefix>
+	<VersionPrefix>0.1.14</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/core/Synapse.Integration/Synapse.Integration.csproj
+++ b/src/core/Synapse.Integration/Synapse.Integration.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
-	<VersionPrefix>0.1.12</VersionPrefix>
+	<VersionPrefix>0.1.14</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/plugins/persistence/Synapse.Plugins.Persistence.EventStore/Synapse.Plugins.Persistence.EventStore.csproj
+++ b/src/plugins/persistence/Synapse.Plugins.Persistence.EventStore/Synapse.Plugins.Persistence.EventStore.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<VersionPrefix>0.1.12</VersionPrefix>
+	<VersionPrefix>0.1.14</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB/Synapse.Plugins.Persistence.MongoDB.csproj
+++ b/src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB/Synapse.Plugins.Persistence.MongoDB.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<VersionPrefix>0.1.12</VersionPrefix>
+	<VersionPrefix>0.1.14</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/runtime/Synapse.Runtime.Docker/Synapse.Runtime.Docker.csproj
+++ b/src/runtime/Synapse.Runtime.Docker/Synapse.Runtime.Docker.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<VersionPrefix>0.1.12</VersionPrefix>
+	<VersionPrefix>0.1.14</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/runtime/Synapse.Runtime.Kubernetes/Configuration/KubernetesRuntimeOptions.cs
+++ b/src/runtime/Synapse.Runtime.Kubernetes/Configuration/KubernetesRuntimeOptions.cs
@@ -49,8 +49,8 @@ namespace Synapse.Runtime.Kubernetes.Configuration
                 {
                     new V1Container("synapse-worker")
                     {
-                        Image = "ghcr.io/serverlessworkflow/synapse-worker:latest",
-                        ImagePullPolicy = "IfNotPresent",
+                        Image = $"ghcr.io/serverlessworkflow/synapse-worker:{typeof(KubernetesRuntimeOptions).Assembly.GetName().Version!.ToString(3)}",
+                        ImagePullPolicy = "Always",
                         Ports = new List<V1ContainerPort>()
                         {
                             new V1ContainerPort()

--- a/src/runtime/Synapse.Runtime.Kubernetes/Synapse.Runtime.Kubernetes.csproj
+++ b/src/runtime/Synapse.Runtime.Kubernetes/Synapse.Runtime.Kubernetes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<VersionPrefix>0.1.12</VersionPrefix>
+		<VersionPrefix>0.1.14</VersionPrefix>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Authors>The Synapse Authors</Authors>
 		<Company>Cloud Native Computing Foundation</Company>

--- a/src/runtime/Synapse.Runtime.Native/Synapse.Runtime.Native.csproj
+++ b/src/runtime/Synapse.Runtime.Native/Synapse.Runtime.Native.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	  <VersionPrefix>0.1.12</VersionPrefix>
+	  <VersionPrefix>0.1.14</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Fixes the default Kubernetes runtime options to always pull the worker image of the current assembly version, instead of latest if not present