### PR TITLE
Updated the IWorkflowProcessManager and IWorkflowRuntime interfaces to accept a V1Workflow argument when creating a new process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,4 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+/deployment/docker-compose/secrets/basic.json

--- a/src/apps/Synapse.Worker/Program.cs
+++ b/src/apps/Synapse.Worker/Program.cs
@@ -36,7 +36,7 @@ using var host = Host.CreateDefaultBuilder(args)
     .ConfigureAppConfiguration(config =>
     {
         config.AddJsonFile("appsettings.json", true, true);
-        config.AddKeyPerFile("/run/secrets", true, true);
+        config.AddKeyPerFile("/run/secrets/synapse", true, true);
     })
     .ConfigureServices((context, services) =>
     {

--- a/src/apps/Synapse.Worker/Services/FileBasedSecretManager.cs
+++ b/src/apps/Synapse.Worker/Services/FileBasedSecretManager.cs
@@ -22,7 +22,7 @@ namespace Synapse.Worker.Services
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "secrets");
                 else
-                    return "/run/secrets/";
+                    return "/run/secrets/synapse";
             }
         }
 

--- a/src/core/Synapse.Application/Commands/WorkflowInstances/v1/V1ResumeWorkflowInstanceCommand.cs
+++ b/src/core/Synapse.Application/Commands/WorkflowInstances/v1/V1ResumeWorkflowInstanceCommand.cs
@@ -64,14 +64,21 @@ namespace Synapse.Application.Commands.WorkflowInstances
         /// <param name="loggerFactory">The service used to create <see cref="ILogger"/>s</param>
         /// <param name="mediator">The service used to mediate calls</param>
         /// <param name="mapper">The service used to map objects</param>
+        /// <param name="workflows">The <see cref="IRepository"/> used to manage <see cref="V1Workflow"/>s</param>
         /// <param name="workflowInstances">The <see cref="IRepository"/> used to manage <see cref="V1WorkflowInstance"/>s</param>
         /// <param name="processManager">The service used to manage <see cref="IWorkflowProcess"/>es</param>
-        public V1ResumeWorkflowInstanceCommandHandler(ILoggerFactory loggerFactory, IMediator mediator, IMapper mapper, IRepository<V1WorkflowInstance> workflowInstances, IWorkflowProcessManager processManager)
+        public V1ResumeWorkflowInstanceCommandHandler(ILoggerFactory loggerFactory, IMediator mediator, IMapper mapper, IRepository<V1Workflow> workflows, IRepository<V1WorkflowInstance> workflowInstances, IWorkflowProcessManager processManager)
             : base(loggerFactory, mediator, mapper)
         {
+            this.Workflows = workflows;
             this.WorkflowInstances = workflowInstances;
             this.ProcessManager = processManager;
         }
+
+        /// <summary>
+        /// Gets the <see cref="IRepository"/> used to manage <see cref="V1Workflow"/>s
+        /// </summary>
+        protected IRepository<V1Workflow> Workflows { get; }
 
         /// <summary>
         /// Gets the <see cref="IRepository"/> used to manage <see cref="V1WorkflowInstance"/>s
@@ -79,7 +86,7 @@ namespace Synapse.Application.Commands.WorkflowInstances
         protected IRepository<V1WorkflowInstance> WorkflowInstances { get; }
 
         /// <summary>
-        /// Gets the current <see cref="IWorkflowProcessManager"/>
+        /// Gets the service used to manage <see cref="IWorkflowProcess"/>es
         /// </summary>
         protected IWorkflowProcessManager ProcessManager { get; }
 
@@ -89,7 +96,10 @@ namespace Synapse.Application.Commands.WorkflowInstances
             var workflowInstance = await this.WorkflowInstances.FindAsync(command.WorkflowInstanceId, cancellationToken);
             if (workflowInstance == null)
                 throw DomainException.NullReference(typeof(V1WorkflowInstance), command.WorkflowInstanceId);
-            var process = await this.ProcessManager.StartProcessAsync(workflowInstance, cancellationToken);
+            var workflow = await this.Workflows.FindAsync(workflowInstance.WorkflowId, cancellationToken);
+            if (workflow == null)
+                throw DomainException.NullReference(typeof(V1Workflow), workflowInstance.WorkflowId);
+            var process = await this.ProcessManager.StartProcessAsync(workflow, workflowInstance, cancellationToken);
             workflowInstance.Resume(process.Id);
             workflowInstance = await this.WorkflowInstances.UpdateAsync(workflowInstance, cancellationToken);
             await this.WorkflowInstances.SaveChangesAsync(cancellationToken);

--- a/src/core/Synapse.Application/Services/WorkflowProcessManager.cs
+++ b/src/core/Synapse.Application/Services/WorkflowProcessManager.cs
@@ -66,11 +66,13 @@ namespace Synapse.Application.Services
         }
 
         /// <inheritdoc/>
-        public virtual async Task<IWorkflowProcess> StartProcessAsync(V1WorkflowInstance workflowInstance, CancellationToken cancellationToken = default)
+        public virtual async Task<IWorkflowProcess> StartProcessAsync(V1Workflow workflow, V1WorkflowInstance workflowInstance, CancellationToken cancellationToken = default)
         {
+            if (workflow == null)
+                throw new ArgumentNullException(nameof(workflow));
             if (workflowInstance == null)
                 throw new ArgumentNullException(nameof(workflowInstance));
-            var process = await this.Runtime.CreateProcessAsync(workflowInstance, cancellationToken);
+            var process = await this.Runtime.CreateProcessAsync(workflow, workflowInstance, cancellationToken);
             process.Logs.SubscribeAsync(async log => await this.OnProcessLogAsync(process, log));
             process.Exited += (sender, e) => this.OnProcessExitedAsync((IWorkflowProcess)sender!);
             process.Disposed += (sender, e) => this.OnProcessDisposed((IWorkflowProcess)sender!);

--- a/src/core/Synapse.Application/Services/WorkflowRuntimeHostBase.cs
+++ b/src/core/Synapse.Application/Services/WorkflowRuntimeHostBase.cs
@@ -40,7 +40,7 @@ namespace Synapse.Application.Services
         protected ILogger Logger { get; }
 
         /// <inheritdoc/>
-        public abstract Task<IWorkflowProcess> CreateProcessAsync(V1WorkflowInstance workflowInstance, CancellationToken cancellationToken = default);
+        public abstract Task<IWorkflowProcess> CreateProcessAsync(V1Workflow workflow, V1WorkflowInstance workflowInstance, CancellationToken cancellationToken = default);
 
         /// <inheritdoc/>
         async ValueTask IAsyncDisposable.DisposeAsync()

--- a/src/core/Synapse.Infrastructure/Services/IWorkflowProcessManager.cs
+++ b/src/core/Synapse.Infrastructure/Services/IWorkflowProcessManager.cs
@@ -30,10 +30,11 @@ namespace Synapse.Infrastructure.Services
         /// <summary>
         /// Starts a new <see cref="IWorkflowProcess"/> for the specified <see cref="V1WorkflowInstance"/>
         /// </summary>
+        /// <param name="workflow">The instanciated <see cref="V1Workflow"/> to start a new <see cref="IWorkflowProcess"/> for</param>
         /// <param name="workflowInstance">The <see cref="V1WorkflowInstance"/> to start a new <see cref="IWorkflowProcess"/> for</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
         /// <returns>A new <see cref="IWorkflowProcess"/></returns>
-        Task<IWorkflowProcess> StartProcessAsync(V1WorkflowInstance workflowInstance, CancellationToken cancellationToken = default);
+        Task<IWorkflowProcess> StartProcessAsync(V1Workflow workflow, V1WorkflowInstance workflowInstance, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the <see cref="IWorkflowProcess"/> with the specified id

--- a/src/core/Synapse.Infrastructure/Services/IWorkflowRuntime.cs
+++ b/src/core/Synapse.Infrastructure/Services/IWorkflowRuntime.cs
@@ -28,10 +28,11 @@ namespace Synapse.Infrastructure.Services
         /// <summary>
         /// Creates a new <see cref="IWorkflowProcess"/> for the specified <see cref="V1WorkflowInstance"/>
         /// </summary>
+        /// <param name="workflow">The instanciated <see cref="V1Workflow"/> to start a new <see cref="IWorkflowProcess"/> for</param>
         /// <param name="workflowInstance">The <see cref="V1WorkflowInstance"/> to create a new <see cref="IWorkflowProcess"/> for</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
         /// <returns>A new <see cref="IWorkflowProcess"/></returns>
-        Task<IWorkflowProcess> CreateProcessAsync(V1WorkflowInstance workflowInstance, CancellationToken cancellationToken = default);
+        Task<IWorkflowProcess> CreateProcessAsync(V1Workflow workflow, V1WorkflowInstance workflowInstance, CancellationToken cancellationToken = default);
 
     }
 

--- a/src/runtime/Synapse.Runtime.Docker/Services/DockerRuntimeHost.cs
+++ b/src/runtime/Synapse.Runtime.Docker/Services/DockerRuntimeHost.cs
@@ -90,13 +90,13 @@ namespace Synapse.Runtime.Services
             }
             finally
             {
-                if (response == null ? true : !response!.Containers.ContainsKey(containerId))
+                if (response == null || !response!.Containers.ContainsKey(containerId))
                     await this.Docker.Networks.ConnectNetworkAsync(this.Options.Network, new NetworkConnectParameters() { Container = containerId }, stoppingToken);
             }
         }
 
         /// <inheritdoc/>
-        public override async Task<IWorkflowProcess> CreateProcessAsync(V1WorkflowInstance workflowInstance, CancellationToken cancellationToken = default)
+        public override async Task<IWorkflowProcess> CreateProcessAsync(V1Workflow workflow, V1WorkflowInstance workflowInstance, CancellationToken cancellationToken = default)
         {
             if (workflowInstance == null)
                 throw new ArgumentNullException(nameof(workflowInstance));
@@ -117,7 +117,7 @@ namespace Synapse.Runtime.Services
                 {
                     Type = "bind",
                     Source = this.Options.Secrets.Directory,
-                    Target = "/run/secrets"
+                    Target = "/run/secrets/synapse"
                 });
             }
             var createContainerParameters = new CreateContainerParameters(containerConfig)


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Updated the IWorkflowProcessManager and IWorkflowRuntime interfaces to accept a V1Workflow argument when creating a new process, thus enabling implementations to analyze and mount required secrets, if anywRuntime interfaces to accept a V1Workflow argument when creating a new process, thus enabling implementations to analyze and mount required secrets, if any