### PR TITLE
Fixed the ConsumeEventProcessor by adding support for the `DataOnly` SW spec property, thus allowing to select the whole enveloppe of consumed cloud events

### DIFF
--- a/src/apps/Synapse.Worker/Services/Processors/EventStateTriggerProcessor.cs
+++ b/src/apps/Synapse.Worker/Services/Processors/EventStateTriggerProcessor.cs
@@ -134,89 +134,87 @@ namespace Synapse.Worker.Services.Processors
         /// <returns>A new awaitable <see cref="Task"/></returns>
         protected virtual async Task OnEventResultAsync(ConsumeEventProcessor processor, V1WorkflowActivityCompletedIntegrationEvent e, CancellationToken cancellationToken)
         {
-            using (var asyncLock = await this.Lock.LockAsync(cancellationToken))
+            using var asyncLock = await this.Lock.LockAsync(cancellationToken);
+            var consumeEventActivities = (await this.Context.Workflow.GetActivitiesAsync(this.Activity, cancellationToken))
+                .Where(a => a.Type == V1WorkflowActivityType.ConsumeEvent)
+                .ToList();
+            if (this.State.Exclusive)
             {
-                var consumeEventActivities = (await this.Context.Workflow.GetActivitiesAsync(this.Activity, cancellationToken))
-                    .Where(a => a.Type == V1WorkflowActivityType.ConsumeEvent)
-                    .ToList();
-                if (this.State.Exclusive)
+                foreach (IWorkflowActivityProcessor childProcessor in this.Processors
+                    .Where(p => p.Activity.Type == V1WorkflowActivityType.ConsumeEvent)
+                    .ToList())
                 {
-                    foreach (IWorkflowActivityProcessor childProcessor in this.Processors
-                        .Where(p => p.Activity.Type == V1WorkflowActivityType.ConsumeEvent)
-                        .ToList())
-                    {
-                        if (childProcessor == processor)
-                            continue;
-                        await childProcessor.TerminateAsync(cancellationToken);
-                        this.Processors.TryRemove(childProcessor);
-                        childProcessor.Dispose();
-                    }
+                    if (childProcessor == processor)
+                        continue;
+                    await childProcessor.TerminateAsync(cancellationToken);
+                    this.Processors.TryRemove(childProcessor);
+                    childProcessor.Dispose();
                 }
-                if (this.State.Exclusive
-                    || (consumeEventActivities.All(p => p.Status == V1WorkflowActivityStatus.Completed) && consumeEventActivities.Count == this.Trigger.Events.Count && !this._Triggered))
+            }
+            if (this.State.Exclusive
+                || (consumeEventActivities.All(p => p.Status == V1WorkflowActivityStatus.Completed) && consumeEventActivities.Count == this.Trigger.Events.Count && !this._Triggered))
+            {
+                this._Triggered = true;
+                var output = this.Activity.Input.ToObject();
+                if (this.Trigger.DataFilter != null
+                    && this.Trigger.DataFilter.UseData)
                 {
-                    this._Triggered = true;
-                    var output = this.Activity.Input.ToObject();
-                    if (this.Trigger.DataFilter != null
-                        && this.Trigger.DataFilter.UseData)
+                    foreach (var consumeEventActivity in consumeEventActivities
+                        .Where(p => p.Status == V1WorkflowActivityStatus.Completed && p.Output != null))
                     {
-                        foreach (var consumeEventActivity in consumeEventActivities
-                            .Where(p => p.Status == V1WorkflowActivityStatus.Completed && p.Output != null))
+                        var eventOutput = consumeEventActivity.Output.ToObject();
+                        if (!string.IsNullOrWhiteSpace(this.Trigger.DataFilter.Data))
+                            eventOutput = await this.Context.EvaluateAsync(this.Trigger.DataFilter.Data, eventOutput, cancellationToken);
+                        if (string.IsNullOrWhiteSpace(this.Trigger.DataFilter.ToStateData))
                         {
-                            var eventOutput = consumeEventActivity.Output.ToObject();
-                            if (!string.IsNullOrWhiteSpace(this.Trigger.DataFilter.Data))
-                                eventOutput = await this.Context.EvaluateAsync(this.Trigger.DataFilter.Data, eventOutput, cancellationToken);
-                            if(string.IsNullOrWhiteSpace(this.Trigger.DataFilter.ToStateData))
-                            {
-                                output = output.Merge(eventOutput);
-                            }
-                            else
-                            {
-                                var expression = this.Trigger.DataFilter.ToStateData.Trim();
-                                var json = await this.JsonSerializer.SerializeAsync(eventOutput, cancellationToken);
-                                if (expression.StartsWith("${"))
-                                    expression = expression[2..^1];
-                                expression = $"{expression} = {json}";
-                                output = await this.Context.EvaluateAsync(expression, output, cancellationToken);
-                            }
+                            output = output.Merge(eventOutput);
+                        }
+                        else
+                        {
+                            var expression = this.Trigger.DataFilter.ToStateData.Trim();
+                            var json = await this.JsonSerializer.SerializeAsync(eventOutput, cancellationToken);
+                            if (expression.StartsWith("${"))
+                                expression = expression[2..^1];
+                            expression = $"{expression} = {json}";
+                            output = await this.Context.EvaluateAsync(expression, output, cancellationToken);
                         }
                     }
-                    if(this.Trigger.Actions == null
-                        || !this.Trigger.Actions.Any())
-                    {
-                        await this.OnNextAsync(new V1WorkflowActivityCompletedIntegrationEvent(this.Activity.Id, output), cancellationToken);
-                        await this.OnCompletedAsync(cancellationToken);
-                        return;
-                    }
-                    var metadata = new Dictionary<string, string>()
+                }
+                if (this.Trigger.Actions == null
+                    || !this.Trigger.Actions.Any())
+                {
+                    await this.OnNextAsync(new V1WorkflowActivityCompletedIntegrationEvent(this.Activity.Id, output), cancellationToken);
+                    await this.OnCompletedAsync(cancellationToken);
+                    return;
+                }
+                var metadata = new Dictionary<string, string>()
                     {
                         { V1WorkflowActivityMetadata.State, this.State.Name! },
                         { V1WorkflowActivityMetadata.Trigger, this.State.Triggers.IndexOf(this.Trigger).ToString() }
                     };
-                    switch (this.Trigger.ActionMode)
-                    {
-                        case ActionExecutionMode.Parallel:
-                            foreach (ActionDefinition triggerAction in this.Trigger.Actions)
-                            {
-                                metadata[V1WorkflowActivityMetadata.Action] = triggerAction.Name!;
-                                await this.Context.Workflow.CreateActivityAsync(V1WorkflowActivityType.Action, await this.Context.FilterInputAsync(triggerAction, output!), metadata, this.Activity, cancellationToken);
-                            }
-                            break;
-                        case ActionExecutionMode.Sequential:
-                            var action = this.Trigger.Actions.First();
-                            metadata[V1WorkflowActivityMetadata.Action] = action.Name!;
-                            await this.Context.Workflow.CreateActivityAsync(V1WorkflowActivityType.Action, await this.Context.FilterInputAsync(action, output!), metadata, this.Activity, cancellationToken);
-                            break;
-                        default:
-                            throw new NotSupportedException($"The specified {nameof(ActionExecutionMode)} '{this.Trigger.ActionMode}' is not supported");
-                    }
-                    foreach (V1WorkflowActivity activity in await this.Context.Workflow.GetOperativeActivitiesAsync(this.Activity, cancellationToken))
-                    {
-                        var childProcessor = this.CreateProcessorFor(activity);
-                        await childProcessor.ProcessAsync(cancellationToken);
-                    }
+                switch (this.Trigger.ActionMode)
+                {
+                    case ActionExecutionMode.Parallel:
+                        foreach (ActionDefinition triggerAction in this.Trigger.Actions)
+                        {
+                            metadata[V1WorkflowActivityMetadata.Action] = triggerAction.Name!;
+                            await this.Context.Workflow.CreateActivityAsync(V1WorkflowActivityType.Action, await this.Context.FilterInputAsync(triggerAction, output!, cancellationToken), metadata, this.Activity, cancellationToken);
+                        }
+                        break;
+                    case ActionExecutionMode.Sequential:
+                        var action = this.Trigger.Actions.First();
+                        metadata[V1WorkflowActivityMetadata.Action] = action.Name!;
+                        await this.Context.Workflow.CreateActivityAsync(V1WorkflowActivityType.Action, await this.Context.FilterInputAsync(action, output!, cancellationToken), metadata, this.Activity, cancellationToken);
+                        break;
+                    default:
+                        throw new NotSupportedException($"The specified {nameof(ActionExecutionMode)} '{this.Trigger.ActionMode}' is not supported");
                 }
-            }   
+                foreach (V1WorkflowActivity activity in await this.Context.Workflow.GetOperativeActivitiesAsync(this.Activity, cancellationToken))
+                {
+                    var childProcessor = this.CreateProcessorFor(activity);
+                    await childProcessor.ProcessAsync(cancellationToken);
+                }
+            }
         }
 
         /// <summary>
@@ -227,11 +225,9 @@ namespace Synapse.Worker.Services.Processors
         /// <returns>A new awaitable <see cref="Task"/></returns>
         protected virtual async Task OnEventCompletedAsync(ConsumeEventProcessor processor, CancellationToken cancellationToken)
         {
-            using (var asyncLock = await this.Lock.LockAsync(cancellationToken))
-            {
-                this.Processors.TryRemove(processor);
-                processor.Dispose();
-            }
+            using var asyncLock = await this.Lock.LockAsync(cancellationToken);
+            this.Processors.TryRemove(processor);
+            processor.Dispose();
         }
 
         /// <summary>
@@ -243,67 +239,65 @@ namespace Synapse.Worker.Services.Processors
         /// <returns>A new awaitable <see cref="Task"/></returns>
         protected virtual async Task OnActionResultAsync(ActionProcessor processor, V1WorkflowActivityCompletedIntegrationEvent e, CancellationToken cancellationToken)
         {
-            using (var asyncLock = await this.Lock.LockAsync(cancellationToken))
+            using var asyncLock = await this.Lock.LockAsync(cancellationToken);
+            if (this.Trigger.ActionMode == ActionExecutionMode.Sequential)
             {
-                if (this.Trigger.ActionMode == ActionExecutionMode.Sequential)
+                if (this.Trigger.TryGetNextAction(processor.Action.Name!, out ActionDefinition action))
                 {
-                    if (this.Trigger.TryGetNextAction(processor.Action.Name!, out ActionDefinition action))
-                    {
-                        var metadata = new Dictionary<string, string>()
+                    var metadata = new Dictionary<string, string>()
                     {
                         { V1WorkflowActivityMetadata.State, this.State.Name! },
                         { V1WorkflowActivityMetadata.Trigger, this.State.Triggers.IndexOf(this.Trigger).ToString() },
                         { V1WorkflowActivityMetadata.Action, action.Name! }
                     };
-                        var activity = await this.Context.Workflow.CreateActivityAsync(V1WorkflowActivityType.Action, await this.Context.FilterInputAsync(action, e.Output), metadata, this.Activity, cancellationToken);
-                        var subProcessor = this.CreateProcessorFor(activity);
-                        await subProcessor.ProcessAsync(cancellationToken);
-                    }
-                    else
-                    {
-                        await this.OnNextAsync(e, cancellationToken);
-                    }
+                    var activity = await this.Context.Workflow.CreateActivityAsync(V1WorkflowActivityType.Action, await this.Context.FilterInputAsync(action, e.Output, cancellationToken), metadata, this.Activity, cancellationToken);
+                    var subProcessor = this.CreateProcessorFor(activity);
+                    await subProcessor.ProcessAsync(cancellationToken);
                 }
                 else
                 {
-                    var childActivities = (await this.Context.Workflow.GetOperativeActivitiesAsync(this.Activity, cancellationToken))
-                        .Where(p => p.Type == V1WorkflowActivityType.Action
-                            && p.Status == V1WorkflowActivityStatus.Completed
-                            && p.Output != null)
-                        .ToList();
-                    if (childActivities.Count == this.Trigger.Actions.Count)
+                    await this.OnNextAsync(e, cancellationToken);
+                }
+            }
+            else
+            {
+                var childActivities = (await this.Context.Workflow.GetOperativeActivitiesAsync(this.Activity, cancellationToken))
+                    .Where(p => p.Type == V1WorkflowActivityType.Action
+                        && p.Status == V1WorkflowActivityStatus.Completed
+                        && p.Output != null)
+                    .ToList();
+                if (childActivities.Count == this.Trigger.Actions.Count)
+                {
+                    var output = new object();
+                    foreach (var activity in childActivities
+                        .Where(p => p.Status == V1WorkflowActivityStatus.Completed && p.Output != null))
                     {
-                        var output = new object();
-                        foreach (var activity in childActivities
-                            .Where(p => p.Status == V1WorkflowActivityStatus.Completed && p.Output != null))
+                        if (!activity.Metadata.TryGetValue(V1WorkflowActivityMetadata.Trigger, out var rawTriggerId))
+                            throw new ArgumentException($"The specified activity '{activity.Id}' is missing the required metadata field '{V1WorkflowActivityMetadata.Trigger}'");
+                        if (!int.TryParse(rawTriggerId, out var triggerId))
+                            throw new ArgumentException($"The '{V1WorkflowActivityMetadata.Trigger}' metadata field of activity '{activity.Id}' is not a valid integer");
+                        if (!this.State.TryGetTrigger(triggerId, out var trigger))
+                            throw new NullReferenceException($"Failed to find a trigger ath the specified index '{triggerId}' in the event state with name '{this.State.Name}'");
+                        if (!trigger.TryGetAction(rawTriggerId, out var action))
+                            throw new NullReferenceException($"Failed to find an action with name '{rawTriggerId}' in the event trigger with at index '{triggerId}', inside state with name '{this.State.Name}'");
+                        if (action.UseResults())
                         {
-                            if (!activity.Metadata.TryGetValue(V1WorkflowActivityMetadata.Trigger, out var rawTriggerId))
-                                throw new ArgumentException($"The specified activity '{activity.Id}' is missing the required metadata field '{V1WorkflowActivityMetadata.Trigger}'");
-                            if (!int.TryParse(rawTriggerId, out var triggerId))
-                                throw new ArgumentException($"The '{V1WorkflowActivityMetadata.Trigger}' metadata field of activity '{activity.Id}' is not a valid integer");
-                            if (!this.State.TryGetTrigger(triggerId, out var trigger))
-                                throw new NullReferenceException($"Failed to find a trigger ath the specified index '{triggerId}' in the event state with name '{this.State.Name}'");
-                            if (!trigger.TryGetAction(rawTriggerId, out var action))
-                                throw new NullReferenceException($"Failed to find an action with name '{rawTriggerId}' in the event trigger with at index '{triggerId}', inside state with name '{this.State.Name}'");
-                            if (action.UseResults())
+                            var expression = action.ActionDataFilter?.ToStateData?.Trim();
+                            var json = await this.JsonSerializer.SerializeAsync(activity.Output, cancellationToken);
+                            if (string.IsNullOrWhiteSpace(expression))
                             {
-                                var expression = action.ActionDataFilter?.ToStateData?.Trim();
-                                var json = await this.JsonSerializer.SerializeAsync(activity.Output, cancellationToken);
-                                if (string.IsNullOrWhiteSpace(expression))
-                                {
-                                    expression = json;
-                                }
-                                else
-                                {
-                                    if (expression.StartsWith("${"))
-                                        expression = expression[2..^1];
-                                    expression = $"{expression} = {json}";
-                                }
-                                output = await this.Context.EvaluateAsync(expression, output, cancellationToken);
+                                expression = json;
                             }
+                            else
+                            {
+                                if (expression.StartsWith("${"))
+                                    expression = expression[2..^1];
+                                expression = $"{expression} = {json}";
+                            }
+                            output = await this.Context.EvaluateAsync(expression, output, cancellationToken);
                         }
-                        await this.OnNextAsync(new V1WorkflowActivityCompletedIntegrationEvent(this.Activity.Id, output), cancellationToken);
                     }
+                    await this.OnNextAsync(new V1WorkflowActivityCompletedIntegrationEvent(this.Activity.Id, output), cancellationToken);
                 }
             }
         }
@@ -316,18 +310,16 @@ namespace Synapse.Worker.Services.Processors
         /// <returns>A new awaitable <see cref="Task"/></returns>
         protected virtual async Task OnActionCompletedAsync(ActionProcessor processor, CancellationToken cancellationToken)
         {
-            using (var asyncLock = await this.Lock.LockAsync(cancellationToken))
+            using var asyncLock = await this.Lock.LockAsync(cancellationToken);
+            this.Processors.TryRemove(processor);
+            processor.Dispose();
+            IEnumerable<V1WorkflowActivity> childActivities = await this.Context.Workflow.GetOperativeActivitiesAsync(this.Activity, cancellationToken);
+            if (childActivities
+                .Where(a => a.Type != V1WorkflowActivityType.End && a.Type != V1WorkflowActivityType.Transition)
+                .All(p => p.Status == V1WorkflowActivityStatus.Completed))
             {
-                this.Processors.TryRemove(processor);
-                processor.Dispose();
-                IEnumerable<V1WorkflowActivity> childActivities = await this.Context.Workflow.GetOperativeActivitiesAsync(this.Activity, cancellationToken);
-                if (childActivities
-                    .Where(a => a.Type != V1WorkflowActivityType.End && a.Type != V1WorkflowActivityType.Transition)
-                    .All(p => p.Status == V1WorkflowActivityStatus.Completed))
-                {
-                    await base.OnCompletedAsync(cancellationToken);
-                    return;
-                }
+                await base.OnCompletedAsync(cancellationToken);
+                return;
             }
         }
 

--- a/src/core/Synapse.Integration/Synapse.Integration.csproj
+++ b/src/core/Synapse.Integration/Synapse.Integration.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Neuroglia.Serialization.Json" Version="2.0.1.70" />
     <PackageReference Include="Neuroglia.Serialization.NewtonsoftJson" Version="2.0.1.70" />
     <PackageReference Include="Neuroglia.Serialization.Protobuf" Version="2.0.1.70" />
-    <PackageReference Include="ServerlessWorkflow.Sdk" Version="0.8.1.8" />
+    <PackageReference Include="ServerlessWorkflow.Sdk" Version="0.8.1.9" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.0" />
   </ItemGroup>
 


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the ConsumeEventProcessor by adding support for the `DataOnly` SW spec property, thus allowing to select the whole enveloppe of consumed cloud events