### PR TITLE
Fixed the DockerRuntimeHost and KubernetesRuntimeHost to duplicate the Container/Pod configuration specified as options, in order to avoid getting spoiled by previous instances

### DIFF
--- a/src/apis/management/Synapse.Apis.Management.Core/Synapse.Apis.Management.Core.csproj
+++ b/src/apis/management/Synapse.Apis.Management.Core/Synapse.Apis.Management.Core.csproj
@@ -5,7 +5,7 @@
 	<RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Core", ""))</RootNamespace>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
-	<VersionPrefix>0.1.21</VersionPrefix>
+	<VersionPrefix>0.1.22</VersionPrefix>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/management/Synapse.Apis.Management.Grpc.Client/Synapse.Apis.Management.Grpc.Client.csproj
+++ b/src/apis/management/Synapse.Apis.Management.Grpc.Client/Synapse.Apis.Management.Grpc.Client.csproj
@@ -5,7 +5,7 @@
 	<RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Client", ""))</RootNamespace>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
-	<VersionPrefix>0.1.21</VersionPrefix>
+	<VersionPrefix>0.1.22</VersionPrefix>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/management/Synapse.Apis.Management.Grpc/Synapse.Apis.Management.Grpc.csproj
+++ b/src/apis/management/Synapse.Apis.Management.Grpc/Synapse.Apis.Management.Grpc.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<VersionPrefix>0.1.21</VersionPrefix>
+		<VersionPrefix>0.1.22</VersionPrefix>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Authors>The Synapse Authors</Authors>
 		<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/management/Synapse.Apis.Management.Http.Client/Synapse.Apis.Management.Http.Client.csproj
+++ b/src/apis/management/Synapse.Apis.Management.Http.Client/Synapse.Apis.Management.Http.Client.csproj
@@ -5,7 +5,7 @@
 	<RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Client", ""))</RootNamespace>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
-	<VersionPrefix>0.1.21</VersionPrefix>
+	<VersionPrefix>0.1.22</VersionPrefix>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/management/Synapse.Apis.Management.Http/Synapse.Apis.Management.Http.csproj
+++ b/src/apis/management/Synapse.Apis.Management.Http/Synapse.Apis.Management.Http.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<VersionPrefix>0.1.21</VersionPrefix>
+		<VersionPrefix>0.1.22</VersionPrefix>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Authors>The Synapse Authors</Authors>
 		<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/management/Synapse.Apis.Management.Ipc.Client/Synapse.Apis.Management.Ipc.Client.csproj
+++ b/src/apis/management/Synapse.Apis.Management.Ipc.Client/Synapse.Apis.Management.Ipc.Client.csproj
@@ -5,7 +5,7 @@
 	<RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Client", ""))</RootNamespace>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
-	<VersionPrefix>0.1.21</VersionPrefix>
+	<VersionPrefix>0.1.22</VersionPrefix>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/monitoring/Synapse.Apis.Monitoring.Core/Synapse.Apis.Monitoring.Core.csproj
+++ b/src/apis/monitoring/Synapse.Apis.Monitoring.Core/Synapse.Apis.Monitoring.Core.csproj
@@ -5,7 +5,7 @@
 	<RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Core", ""))</RootNamespace>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
-	<VersionPrefix>0.1.21</VersionPrefix>
+	<VersionPrefix>0.1.22</VersionPrefix>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/monitoring/Synapse.Apis.Monitoring.WebSocket/Synapse.Apis.Monitoring.WebSocket.csproj
+++ b/src/apis/monitoring/Synapse.Apis.Monitoring.WebSocket/Synapse.Apis.Monitoring.WebSocket.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<VersionPrefix>0.1.21</VersionPrefix>
+		<VersionPrefix>0.1.22</VersionPrefix>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Authors>The Synapse Authors</Authors>
 		<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/runtime/Synapse.Apis.Runtime.Core/Synapse.Apis.Runtime.Core.csproj
+++ b/src/apis/runtime/Synapse.Apis.Runtime.Core/Synapse.Apis.Runtime.Core.csproj
@@ -5,7 +5,7 @@
 	<RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Core", ""))</RootNamespace>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
-	<VersionPrefix>0.1.21</VersionPrefix>
+	<VersionPrefix>0.1.22</VersionPrefix>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/runtime/Synapse.Apis.Runtime.Grpc.Client/Synapse.Apis.Runtime.Grpc.Client.csproj
+++ b/src/apis/runtime/Synapse.Apis.Runtime.Grpc.Client/Synapse.Apis.Runtime.Grpc.Client.csproj
@@ -5,7 +5,7 @@
 	<RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Client", ""))</RootNamespace>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
-	<VersionPrefix>0.1.21</VersionPrefix>
+	<VersionPrefix>0.1.22</VersionPrefix>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/runtime/Synapse.Apis.Runtime.Grpc/Synapse.Apis.Runtime.Grpc.csproj
+++ b/src/apis/runtime/Synapse.Apis.Runtime.Grpc/Synapse.Apis.Runtime.Grpc.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<VersionPrefix>0.1.21</VersionPrefix>
+		<VersionPrefix>0.1.22</VersionPrefix>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Authors>The Synapse Authors</Authors>
 		<Company>Cloud Native Computing Foundation</Company>

--- a/src/apis/runtime/Synapse.Apis.Runtime.Ipc.Client/Synapse.Apis.Runtime.Ipc.Client.csproj
+++ b/src/apis/runtime/Synapse.Apis.Runtime.Ipc.Client/Synapse.Apis.Runtime.Ipc.Client.csproj
@@ -5,7 +5,7 @@
 	<RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Client", ""))</RootNamespace>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
-	<VersionPrefix>0.1.21</VersionPrefix>
+	<VersionPrefix>0.1.22</VersionPrefix>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/apps/Synapse.Cli/Synapse.Cli.csproj
+++ b/src/apps/Synapse.Cli/Synapse.Cli.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<OutputType>Exe</OutputType>
-	<VersionPrefix>0.1.21</VersionPrefix>
+	<VersionPrefix>0.1.22</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/apps/Synapse.Server/Synapse.Server.csproj
+++ b/src/apps/Synapse.Server/Synapse.Server.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<VersionPrefix>0.1.21</VersionPrefix>
+	<VersionPrefix>0.1.22</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/apps/Synapse.Worker/Synapse.Worker.csproj
+++ b/src/apps/Synapse.Worker/Synapse.Worker.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<OutputType>Exe</OutputType>
-	<VersionPrefix>0.1.21</VersionPrefix>
+	<VersionPrefix>0.1.22</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/core/Synapse.Application/Synapse.Application.csproj
+++ b/src/core/Synapse.Application/Synapse.Application.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<VersionPrefix>0.1.21</VersionPrefix>
+	<VersionPrefix>0.1.22</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/core/Synapse.Domain/Synapse.Domain.csproj
+++ b/src/core/Synapse.Domain/Synapse.Domain.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	  <VersionPrefix>0.1.21</VersionPrefix>
+	  <VersionPrefix>0.1.22</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/core/Synapse.Infrastructure/Synapse.Infrastructure.csproj
+++ b/src/core/Synapse.Infrastructure/Synapse.Infrastructure.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<VersionPrefix>0.1.21</VersionPrefix>
+	<VersionPrefix>0.1.22</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/core/Synapse.Integration/Synapse.Integration.csproj
+++ b/src/core/Synapse.Integration/Synapse.Integration.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
-	<VersionPrefix>0.1.21</VersionPrefix>
+	<VersionPrefix>0.1.22</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/plugins/persistence/Synapse.Plugins.Persistence.EventStore/Synapse.Plugins.Persistence.EventStore.csproj
+++ b/src/plugins/persistence/Synapse.Plugins.Persistence.EventStore/Synapse.Plugins.Persistence.EventStore.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<VersionPrefix>0.1.21</VersionPrefix>
+	<VersionPrefix>0.1.22</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/plugins/persistence/Synapse.Plugins.Persistence.EventStore/plugin.json
+++ b/src/plugins/persistence/Synapse.Plugins.Persistence.EventStore/plugin.json
@@ -6,6 +6,6 @@
   "copyright": "Copyright © 2022-Present The Synapse Authors. All Rights Reserved.",
   "licenseUri": "https://raw.githubusercontent.com/serverlessworkflow/synapse/main/LICENSE",
   "repositoryUri": "https://github.com/serverlessworkflow/synapse",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "assemblyFile": "Synapse.Plugins.Persistence.EventStore.dll"
 }

--- a/src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB/Synapse.Plugins.Persistence.MongoDB.csproj
+++ b/src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB/Synapse.Plugins.Persistence.MongoDB.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<VersionPrefix>0.1.21</VersionPrefix>
+	<VersionPrefix>0.1.22</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB/plugin.json
+++ b/src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB/plugin.json
@@ -6,6 +6,6 @@
   "copyright": "Copyright © 2022-Present The Synapse Authors. All Rights Reserved.",
   "licenseUri": "https://raw.githubusercontent.com/serverlessworkflow/synapse/main/LICENSE",
   "repositoryUri": "https://github.com/serverlessworkflow/synapse",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "assemblyFile": "Synapse.Plugins.Persistence.MongoDB.dll"
 }

--- a/src/runtime/Synapse.Runtime.Docker/Services/DockerRuntimeHost.cs
+++ b/src/runtime/Synapse.Runtime.Docker/Services/DockerRuntimeHost.cs
@@ -18,6 +18,7 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 using Synapse.Application.Configuration;
 using Synapse.Application.Services;
 using Synapse.Domain.Models;
@@ -101,7 +102,9 @@ namespace Synapse.Runtime.Services
             if (workflowInstance == null)
                 throw new ArgumentNullException(nameof(workflowInstance));
             await this.PullWorkerImageAsync(cancellationToken);
-            var containerConfig = this.Options.Runtime.Container;
+            if (this.Options.Runtime.Container == null)
+                throw new Exception($"The '{nameof(DockerRuntimeOptions)}.{nameof(DockerRuntimeOptions.Container)}' property must be set and cannot be null");
+            var containerConfig = JsonConvert.DeserializeObject<Config>(JsonConvert.SerializeObject(this.Options.Runtime.Container))!;
             containerConfig.AddOrUpdateEnvironmentVariable(EnvironmentVariables.Api.HostName.Name, EnvironmentVariables.Api.HostName.Value!); //todo: instead, fetch values from options
             containerConfig.AddOrUpdateEnvironmentVariable(EnvironmentVariables.Runtime.WorkflowInstanceId.Name, workflowInstance.Id.ToString()); //todo: instead, fetch values from options
             if (this.ApplicationOptions.SkipCertificateValidation)

--- a/src/runtime/Synapse.Runtime.Docker/Synapse.Runtime.Docker.csproj
+++ b/src/runtime/Synapse.Runtime.Docker/Synapse.Runtime.Docker.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<VersionPrefix>0.1.21</VersionPrefix>
+	<VersionPrefix>0.1.22</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>

--- a/src/runtime/Synapse.Runtime.Kubernetes/Services/KubernetesRuntimeHost.cs
+++ b/src/runtime/Synapse.Runtime.Kubernetes/Services/KubernetesRuntimeHost.cs
@@ -22,6 +22,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Neuroglia;
 using Neuroglia.K8s;
+using Newtonsoft.Json;
 using Synapse.Application.Configuration;
 using Synapse.Application.Services;
 using Synapse.Domain.Models;
@@ -107,9 +108,9 @@ namespace Synapse.Runtime.Kubernetes.Services
                 throw new ArgumentNullException(nameof(workflow));
             if (workflowInstance == null)
                 throw new ArgumentNullException(nameof(workflowInstance));
-            var pod = this.Options.WorkerPod;
-            if (pod == null)
+            if (this.Options.WorkerPod == null)
                 throw new Exception($"The '{nameof(KubernetesRuntimeOptions)}.{nameof(KubernetesRuntimeOptions.WorkerPod)}' property must be set and cannot be null");
+            var pod = JsonConvert.DeserializeObject<V1Pod>(JsonConvert.SerializeObject(this.Options.WorkerPod))!;
             if (pod.Metadata == null)
                 pod.Metadata = new();
             pod.Metadata.Name = workflowInstance.Id;

--- a/src/runtime/Synapse.Runtime.Kubernetes/Synapse.Runtime.Kubernetes.csproj
+++ b/src/runtime/Synapse.Runtime.Kubernetes/Synapse.Runtime.Kubernetes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<VersionPrefix>0.1.21</VersionPrefix>
+		<VersionPrefix>0.1.22</VersionPrefix>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Authors>The Synapse Authors</Authors>
 		<Company>Cloud Native Computing Foundation</Company>

--- a/src/runtime/Synapse.Runtime.Native/Synapse.Runtime.Native.csproj
+++ b/src/runtime/Synapse.Runtime.Native/Synapse.Runtime.Native.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	  <VersionPrefix>0.1.21</VersionPrefix>
+	  <VersionPrefix>0.1.22</VersionPrefix>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Authors>The Synapse Authors</Authors>
 	<Company>Cloud Native Computing Foundation</Company>


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Fixes the DockerRuntimeHost and KubernetesRuntimeHost to duplicate the Container/Pod configuration specified as options, in order to avoid getting corrupted by previous instances