### PR TITLE
Fixed the AsyncApiFunctionProcessor, BranchProcess and OpenApiFunctionProcessor to throw more detailed exceptions when handling non-sucessfull HTTP responses

### DIFF
--- a/src/apps/Synapse.Worker/Extensions/HttpResponseMessageExtensions.cs
+++ b/src/apps/Synapse.Worker/Extensions/HttpResponseMessageExtensions.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * Copyright © 2022-Present The Synapse Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Synapse.Worker
+{
+    /// <summary>
+    /// Defines extensions for <see cref="HttpResponseMessage"/>s
+    /// </summary>
+    public static class HttpResponseMessageExtensions
+    {
+
+        /// <summary>
+        /// Ensures that the <see cref="HttpResponseMessage"/> returned a success status code, and throws if it's not the case
+        /// </summary>
+        /// <param name="response">The <see cref="HttpResponseMessage"/></param>
+        /// <param name="responseContent">The reponse contents, if any</param>
+        /// <exception cref="HttpRequestException">The exception is thrown if the <see cref="HttpResponseMessage"/> has a non-success status code</exception>
+        public static void EnsureSuccessStatusCode(this HttpResponseMessage response, string? responseContent)
+        {
+            if (response.IsSuccessStatusCode)
+                return;
+            throw new HttpRequestException($"The server responsed with a non-success status code '{(int)response.StatusCode} {response.StatusCode}' to HTTP request {response.RequestMessage!.Method} {response.RequestMessage!.RequestUri}{Environment.NewLine}{(string.IsNullOrWhiteSpace(responseContent) ? "" : responseContent)}", null, response.StatusCode);
+        }
+
+    }
+
+}

--- a/src/apps/Synapse.Worker/Services/OAuth2TokenManager.cs
+++ b/src/apps/Synapse.Worker/Services/OAuth2TokenManager.cs
@@ -94,7 +94,7 @@ namespace Synapse.Worker.Services
             if (!response.IsSuccessStatusCode)
             {
                 this.Logger.LogError("An error occured while generating a new JWT token: {details}", json);
-                response.EnsureSuccessStatusCode();
+                response.EnsureSuccessStatusCode(json);
             }
             token = await this.JsonSerializer.DeserializeAsync<OAuth2Token>(json, cancellationToken);
             this.Tokens[tokenKey] = token;

--- a/src/apps/Synapse.Worker/Services/Processors/AsyncApiFunctionProcessor.cs
+++ b/src/apps/Synapse.Worker/Services/Processors/AsyncApiFunctionProcessor.cs
@@ -132,9 +132,10 @@ namespace Synapse.Worker.Services.Processors
                     using HttpResponseMessage response = await this.HttpClient.SendAsync(request, cancellationToken);
                     if (!response.IsSuccessStatusCode)
                     {
+                        var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
                         this.Logger.LogInformation("Failed to retrieve the Async API document at location '{uri}'. The remote server responded with a non-success status code '{statusCode}'.", asyncApiUri, response.StatusCode);
-                        this.Logger.LogDebug("Response content:/r/n{responseContent}", response.Content == null ? "None" : await response.Content.ReadAsStringAsync(cancellationToken));
-                        response.EnsureSuccessStatusCode();
+                        this.Logger.LogDebug("Response content:/r/n{responseContent}", response.Content == null ? "None" : responseContent);
+                        response.EnsureSuccessStatusCode(responseContent);
                     }
                     using Stream responseStream = await response.Content!.ReadAsStreamAsync(cancellationToken)!;
                     this.Document = await this.AsyncApiReader.ReadAsync(responseStream, cancellationToken);

--- a/src/apps/Synapse.Worker/Services/Processors/BranchProcessor.cs
+++ b/src/apps/Synapse.Worker/Services/Processors/BranchProcessor.cs
@@ -115,9 +115,7 @@ namespace Synapse.Worker.Services.Processors
             }
             foreach (var activity in await this.Context.Workflow.GetOperativeActivitiesAsync(this.Activity, cancellationToken))
             {
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                 this.CreateProcessorFor(activity);
-#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             }
         }
 


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Fixes the AsyncApiFunctionProcessor, BranchProcess and OpenApiFunctionProcessor to throw more detailed exceptions when handling non-sucessfull HTTP responses