### PR TITLE
Fixed the V1WorkflowsController by calling the proper V1GetWorkflowByIdQuery (instead of GenericQuery) when executing action GetById

### DIFF
--- a/src/apis/management/Synapse.Apis.Management.Http/Controllers/V1WorkflowsController.cs
+++ b/src/apis/management/Synapse.Apis.Management.Http/Controllers/V1WorkflowsController.cs
@@ -80,7 +80,7 @@ namespace Synapse.Apis.Management.Http.Controllers
         [ProducesResponseType((int)HttpStatusCode.Forbidden)]
         public async Task<IActionResult> GetById(string id, CancellationToken cancellationToken)
         {
-            return this.Process(await this.Mediator.ExecuteAsync(new Application.Queries.Generic.V1FindByIdQuery<Integration.Models.V1Workflow, string>(id), cancellationToken));
+            return this.Process(await this.Mediator.ExecuteAsync(Application.Queries.Workflows.V1GetWorkflowByIdQuery.Parse(id), cancellationToken));
         }
 
         /// <summary>

--- a/src/core/Synapse.Application/Queries/Workflows/V1GetWorkflowByIdQuery.cs
+++ b/src/core/Synapse.Application/Queries/Workflows/V1GetWorkflowByIdQuery.cs
@@ -54,6 +54,23 @@ namespace Synapse.Application.Queries.Workflows
         /// </summary>
         public virtual string? Version { get; protected set; } = null!;
 
+        /// <summary>
+        /// Parses the specified reference into a new <see cref="V1GetWorkflowByIdQuery"/>
+        /// </summary>
+        /// <param name="reference">The reference to parse</param>
+        /// <returns>A new <see cref="V1GetWorkflowByIdQuery"/></returns>
+        public static V1GetWorkflowByIdQuery Parse(string reference)
+        {
+            if (string.IsNullOrEmpty(reference))
+                throw new ArgumentNullException(nameof(reference));
+            var components = reference.Split(':', StringSplitOptions.RemoveEmptyEntries);
+            var id = components.First();
+            string? version = null;
+            if (components.Length == 2)
+                version = components.Last();
+            return new(id, version);
+        }
+
     }
 
     /// <summary>


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Fixes the V1WorkflowsController by calling the proper V1GetWorkflowByIdQuery (instead of GenericQuery) when executing action GetById