### PR TITLE
Fixed the V1EventFilter and its DTO to properly filter events in order to prevent correlating unrelated instances that define the same condition

### DIFF
--- a/src/core/Synapse.Domain/Models/v1/V1EventFilter.cs
+++ b/src/core/Synapse.Domain/Models/v1/V1EventFilter.cs
@@ -75,6 +75,13 @@ namespace Synapse.Domain.Models
                 if (!Regex.IsMatch(value, attribute.Value, RegexOptions.IgnoreCase))
                     return false;
             }
+            foreach (var mapping in this.CorrelationMappings)
+            {
+                if (!e.TryGetAttribute(mapping.Key, out var value))
+                    return false;
+                if (!mapping.Value.Equals(value, StringComparison.OrdinalIgnoreCase))
+                    return false;
+            }
             return true;
         }
 

--- a/src/core/Synapse.Integration/Models/v1/V1EventFilter.cs
+++ b/src/core/Synapse.Integration/Models/v1/V1EventFilter.cs
@@ -38,6 +38,13 @@ namespace Synapse.Integration.Models
                 if (!Regex.IsMatch(value, attribute.Value, RegexOptions.IgnoreCase))
                     return false;
             }
+            foreach (var mapping in this.CorrelationMappings)
+            {
+                if (!e.TryGetAttribute(mapping.Key, out var value))
+                    return false;
+                if (!mapping.Value.Equals(value, StringComparison.OrdinalIgnoreCase))
+                    return false;
+            }
             return true;
         }
 

--- a/src/dashboard/Synapse.Dashboard/Features/Shared/WorkflowDiagram/WorkflowGraphBuilder.cs
+++ b/src/dashboard/Synapse.Dashboard/Features/Shared/WorkflowDiagram/WorkflowGraphBuilder.cs
@@ -247,17 +247,17 @@ namespace Synapse.Dashboard
                             {
                                 case SwitchStateType.Data:
                                     {
-                                        foreach (var condition in switchState.DataConditions)
+                                        foreach (var condition in switchState.DataConditions!)
                                         {
                                             var caseNode = this.BuildDataConditionNode(condition.Name!); // todo: should be a labeled edge, not a node?
                                             await stateNodeGroup.AddChildAsync(caseNode);
                                             await this.BuildEdgeBetween(graph, firstNode, caseNode, state.UsedForCompensation);
-                                            switch (condition.Type)
+                                            switch (condition.OutcomeType)
                                             {
-                                                case ConditionType.End:
+                                                case SwitchCaseOutcomeType.End:
                                                     await this.BuildEdgeBetween(graph, caseNode, endNode, state.UsedForCompensation);
                                                     break;
-                                                case ConditionType.Transition:
+                                                case SwitchCaseOutcomeType.Transition:
                                                     var nextStateName = condition.Transition == null ? condition.TransitionToStateName : condition.Transition.NextState;
                                                     var nextState = definition.GetState(nextStateName!);
                                                     if (nextState == null)
@@ -266,7 +266,7 @@ namespace Synapse.Dashboard
                                                     lastNode = nextStateNode.Children.Values.OfType<NodeViewModel>().Last();
                                                     break;
                                                 default:
-                                                    throw new Exception($"The specified condition type '${condition.Type}' is not supported");
+                                                    throw new Exception($"The specified condition type '${condition.OutcomeType}' is not supported");
                                             }
                                         }
                                         var defaultCaseNode = this.BuildDataConditionNode("default");
@@ -299,18 +299,18 @@ namespace Synapse.Dashboard
                                     break;
                                 case SwitchStateType.Event:
                                     {
-                                        foreach (var condition in switchState.EventConditions)
+                                        foreach (var condition in switchState.EventConditions!)
                                         {
                                             Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(condition));
                                             var caseNode = this.BuildDataConditionNode(condition.Name ?? condition.Event); // todo: should be a labeled edge, not a node?
                                             await stateNodeGroup.AddChildAsync(caseNode);
                                             await this.BuildEdgeBetween(graph, firstNode, caseNode, state.UsedForCompensation);
-                                            switch (condition.Type)
+                                            switch (condition.OutcomeType)
                                             {
-                                                case ConditionType.End:
+                                                case SwitchCaseOutcomeType.End:
                                                     await this.BuildEdgeBetween(graph, caseNode, endNode, state.UsedForCompensation);
                                                     break;
-                                                case ConditionType.Transition:
+                                                case SwitchCaseOutcomeType.Transition:
                                                     var nextStateName = condition.Transition == null ? condition.TransitionToStateName : condition.Transition.NextState;
                                                     var nextState = definition.GetState(nextStateName!);
                                                     if (nextState == null)
@@ -319,7 +319,7 @@ namespace Synapse.Dashboard
                                                     lastNode = nextStateNode.Children.Values.OfType<NodeViewModel>().Last();
                                                     break;
                                                 default:
-                                                    throw new Exception($"The specified condition type '${condition.Type}' is not supported");
+                                                    throw new Exception($"The specified condition type '${condition.OutcomeType}' is not supported");
                                             }
                                         }
                                         var defaultCaseNode = this.BuildDataConditionNode("default");


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Fixes the V1EventFilter and its DTO to properly filter events in order to prevent correlating unrelated instances that define the same condition