### PR TITLE
Fixed all HTTP Management API controllers to support the '$search' ODATA clause by manually filtering based on bound search expression

### DIFF
--- a/src/apis/management/Synapse.Apis.Management.Http/Controllers/V1CorrelationsController.cs
+++ b/src/apis/management/Synapse.Apis.Management.Http/Controllers/V1CorrelationsController.cs
@@ -69,15 +69,16 @@ namespace Synapse.Apis.Management.Http.Controllers
         /// Queries correlations
         /// <para>This endpoint supports ODATA.</para>
         /// </summary>
+        /// <param name="queryOptions">The options used to configure the query to perform</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
         /// <returns>A new <see cref="IActionResult"/></returns>
         [HttpGet, EnableQuery]
         [ProducesResponseType(typeof(IEnumerable<Integration.Models.V1Correlation>), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-        public async Task<IActionResult> Get(CancellationToken cancellationToken)
+        public async Task<IActionResult> Get(ODataQueryOptions<Integration.Models.V1Correlation> queryOptions, CancellationToken cancellationToken)
         {
-            return this.Process(await this.Mediator.ExecuteAsync(new Application.Queries.Generic.V1ListQuery<Integration.Models.V1Correlation>(), cancellationToken));
+            return this.Process(await this.Mediator.ExecuteAsync(new Application.Queries.Generic.V1FilterQuery<Integration.Models.V1Correlation>(queryOptions), cancellationToken));
         }
 
         /// <summary>

--- a/src/apis/management/Synapse.Apis.Management.Http/Controllers/V1WorkflowActivitiesController.cs
+++ b/src/apis/management/Synapse.Apis.Management.Http/Controllers/V1WorkflowActivitiesController.cs
@@ -17,6 +17,7 @@
 
 namespace Synapse.Apis.Management.Http.Controllers
 {
+
     /// <summary>
     /// Represents the <see cref="ApiController"/> used to manage workflow activities
     /// </summary>
@@ -52,15 +53,16 @@ namespace Synapse.Apis.Management.Http.Controllers
         /// Queries workflow activities
         /// <para>This endpoint supports ODATA.</para>
         /// </summary>
+        /// <param name="queryOptions">The options used to configure the query to perform</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
         /// <returns>A new <see cref="IActionResult"/></returns>
         [HttpGet, EnableQuery]
         [ProducesResponseType(typeof(IEnumerable<Integration.Models.V1WorkflowActivity>), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-        public async Task<IActionResult> Get(CancellationToken cancellationToken)
+        public async Task<IActionResult> Get(ODataQueryOptions<Integration.Models.V1WorkflowActivity> queryOptions, CancellationToken cancellationToken)
         {
-            return this.Process(await this.Mediator.ExecuteAsync(new Application.Queries.Generic.V1ListQuery<Integration.Models.V1WorkflowActivity>(), cancellationToken));
+            return this.Process(await this.Mediator.ExecuteAsync(new Application.Queries.Generic.V1FilterQuery<Integration.Models.V1WorkflowActivity>(queryOptions), cancellationToken));
         }
 
     }

--- a/src/apis/management/Synapse.Apis.Management.Http/Controllers/V1WorkflowInstancesController.cs
+++ b/src/apis/management/Synapse.Apis.Management.Http/Controllers/V1WorkflowInstancesController.cs
@@ -71,15 +71,16 @@ namespace Synapse.Apis.Management.Http.Controllers
         /// Queries workflow instances
         /// <para>This endpoint supports ODATA.</para>
         /// </summary>
+        /// <param name="queryOptions">The options used to configure the query to perform</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
         /// <returns>A new <see cref="IActionResult"/></returns>
         [HttpGet, EnableQuery]
         [ProducesResponseType(typeof(IEnumerable<Integration.Models.V1WorkflowInstance>), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-        public async Task<IActionResult> Get(CancellationToken cancellationToken)
+        public async Task<IActionResult> Get(ODataQueryOptions<Integration.Models.V1WorkflowInstance> queryOptions, CancellationToken cancellationToken)
         {
-            return this.Process(await this.Mediator.ExecuteAsync(new Application.Queries.Generic.V1ListQuery<Integration.Models.V1WorkflowInstance>(), cancellationToken));
+            return this.Process(await this.Mediator.ExecuteAsync(new Application.Queries.Generic.V1FilterQuery<Integration.Models.V1WorkflowInstance>(queryOptions), cancellationToken));
         }
 
         /// <summary>

--- a/src/apis/management/Synapse.Apis.Management.Http/Controllers/V1WorkflowsController.cs
+++ b/src/apis/management/Synapse.Apis.Management.Http/Controllers/V1WorkflowsController.cs
@@ -104,15 +104,16 @@ namespace Synapse.Apis.Management.Http.Controllers
         /// Queries workflows
         /// <para>This endpoint supports ODATA.</para>
         /// </summary>
+        /// <param name="queryOptions">The options of the ODATA query to perform</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
         /// <returns>A new <see cref="IActionResult"/></returns>
         [HttpGet, EnableQuery]
         [ProducesResponseType(typeof(IEnumerable<Integration.Models.V1Workflow>), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-        public async Task<IActionResult> Get(CancellationToken cancellationToken)
+        public async Task<IActionResult> Get(ODataQueryOptions<Integration.Models.V1Workflow> queryOptions, CancellationToken cancellationToken)
         {
-            return this.Process(await this.Mediator.ExecuteAsync(new Application.Queries.Generic.V1ListQuery<Integration.Models.V1Workflow>(), cancellationToken));
+            return this.Process(await this.Mediator.ExecuteAsync(new Application.Queries.Generic.V1FilterQuery<Integration.Models.V1Workflow>(queryOptions), cancellationToken));
         }
 
         /// <summary>

--- a/src/apis/management/Synapse.Apis.Management.Http/Extensions/ISynapseApplicationBuilderExtensions.cs
+++ b/src/apis/management/Synapse.Apis.Management.Http/Extensions/ISynapseApplicationBuilderExtensions.cs
@@ -44,12 +44,14 @@ namespace Synapse.Apis.Management.Http
         /// <returns>The configured <see cref="ISynapseApplicationBuilder"/></returns>
         public static ISynapseApplicationBuilder UseHttpManagementApi(this ISynapseApplicationBuilder synapse)
         {
+            var searchBinder = new ODataSearchBinder();
+            synapse.Services.AddSingleton<ISearchBinder>(searchBinder);
             synapse.Services
                 .AddControllers()
                 .AddOData((options, provider) =>
                 {
                     IEdmModelBuilder builder = provider.GetRequiredService<IEdmModelBuilder>();
-                    options.AddRouteComponents("api/odata", builder.Build(), services => services.AddSingleton<ISearchBinder, ODataSearchBinder>())
+                    options.AddRouteComponents("api/odata", builder.Build(), services => services.AddSingleton<ISearchBinder>(searchBinder))
                         .EnableQueryFeatures(50);
                     options.RouteOptions.EnableControllerNameCaseInsensitive = true;
                     options.RouteOptions.EnableActionNameCaseInsensitive = true;


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Fixes all HTTP Management API controllers to support the '$search' ODATA clause by manually filtering based on bound search expression