### PR TITLE
Fixed the V1GetWorkflowByIdQueryHandler by sorting workflows by SemVersion rather than by string

### DIFF
--- a/src/core/Synapse.Application/Queries/Workflows/V1GetWorkflowByIdQuery.cs
+++ b/src/core/Synapse.Application/Queries/Workflows/V1GetWorkflowByIdQuery.cs
@@ -15,6 +15,8 @@
  *
  */
 
+using Semver;
+
 namespace Synapse.Application.Queries.Workflows
 {
 
@@ -97,7 +99,8 @@ namespace Synapse.Application.Queries.Workflows
             {
                 workflow = this.Repository.AsQueryable()
                     .Where(wf => wf.Definition.Id!.Equals(query.Id, StringComparison.OrdinalIgnoreCase))
-                    .OrderByDescending(wf => wf.Definition.Version)
+                    .ToList()
+                    .OrderByDescending(wf => SemVersion.Parse(wf.Definition.Version, SemVersionStyles.Any))
                     .FirstOrDefault()!;
             }
             else

--- a/src/core/Synapse.Application/Synapse.Application.csproj
+++ b/src/core/Synapse.Application/Synapse.Application.csproj
@@ -34,6 +34,7 @@
 	<PackageReference Include="Neuroglia.Data.DistributedCache" Version="2.0.1.88" />
 	<PackageReference Include="Neuroglia.Data.EventSourcing" Version="2.0.1.88" />
 	<PackageReference Include="Neuroglia.Mediation.FluentValidation" Version="2.0.1.88" />
+	<PackageReference Include="Semver" Version="2.2.0" />
 	<PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Fixed the V1GetWorkflowByIdQueryHandler by sorting workflows by SemVersion rather than by string