### PR TITLE
Fixed the OpenApiFunctionProcessor, which was trying to build the function's arguments, even though the function reference did not define any

### DIFF
--- a/src/apps/Synapse.Worker/Services/Processors/OpenApiFunctionProcessor.cs
+++ b/src/apps/Synapse.Worker/Services/Processors/OpenApiFunctionProcessor.cs
@@ -174,6 +174,8 @@ namespace Synapse.Worker.Services.Processors
                     .Single(p => p.Value.Operations.Any(o => o.Value.OperationId == operation.Value.OperationId));
                 this.Path = path.Key;
                 await this.BuildParametersAsync(cancellationToken);
+                if (this.Parameters == null)
+                    return;
                 var parameters = path.Value.Parameters.ToList();
                 parameters.AddRange(this.Operation.Parameters);
                 foreach (OpenApiParameter param in parameters


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Fixes the OpenApiFunctionProcessor, which was trying to build the function's arguments, even though the function reference did not define any