### PR TITLE
ci(Versioning): Update command due to recent breaking changes to Versioning.NET

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -25,4 +25,4 @@ jobs:
 
       - name: Increment Version
         run: |
-          dotnet-version increment-version-with-git -g "." --branch-name ${{ github.ref_name }} --author-email ${{ secrets.BOT_EMAIL }}
+          dotnet-version increment-version-with-git-hints -g "." --branch-name ${{ github.ref_name }} --author-email ${{ secrets.BOT_EMAIL }}


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
Recently, Versioning.NET tool received a breaking change update and since this pipeline does not target a specific version, this will avoid the pipeline breaking in the future by accounting for the breaking change.