### PR TITLE
fix(Dashboard): trimmed jq expression in editor

### DIFF
--- a/src/dashboard/Synapse.Dashboard/Features/Shared/Jq/InputJqExpression.razor
+++ b/src/dashboard/Synapse.Dashboard/Features/Shared/Jq/InputJqExpression.razor
@@ -105,12 +105,15 @@
     {
         if (string.IsNullOrWhiteSpace(this.CurrentValue))
             return;
+        var trimmedExpression = this.CurrentValue.TrimStart('$').TrimStart('{').TrimEnd('}').Trim();
+        if (string.IsNullOrWhiteSpace(trimmedExpression))
+            return;
         var json = await this.editor.GetValue();
         if (this.MonacoEditorHelper.PreferedLanguage == PreferedLanguage.YAML)
         {
             json = await this.YamlConverter.YamlToJson(json);
         }
-        this.output = await this.JsRuntime.InvokeAsync<string>("jq.raw", json, this.CurrentValue);
+        this.output = await this.JsRuntime.InvokeAsync<string>("jq.raw", json, trimmedExpression);
         // todo: try/catch, display error ?
     }
 

--- a/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/EventCaseEditor.razor
+++ b/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/EventCaseEditor.razor
@@ -23,7 +23,7 @@
             <tr>
                 <td>Name</td>
                 <td>
-                    <input type="text" value="@eventCase.Name" required placeholder="My event case" title="The name of the case" class="form-control"
+                    <input type="text" value="@eventCase.Name" required placeholder="My event case name" title="The name of the case" class="form-control"
                     @onchange="async e => await OnChangeAsync(c => c.Name = (string)e.Value!)"/>
                 </td>
             </tr>
@@ -31,24 +31,19 @@
                 <td>Event</td>
                 <td>
                     <EventSelector 
-                    Selected="string.IsNullOrWhiteSpace(eventCase.Event) ? null : Workflow.GetEvent(eventCase.Event)"
-                    Events="Workflow.Events?.Where(e => e.Kind == EventKind.Consumed).ToList()"/>
-                    <JqExpressionEditor
-                        Expression="@eventCase.Event" 
-                        placeholder="${ . }" 
-                        title="A runtime expression producing a boolean that indicates whether or not the case conditions are met" 
-                        class="form-control"
-                        OnChange="async e => await OnChangeAsync(c => c.Event = e)"
-                    />
+                        Selected="string.IsNullOrWhiteSpace(eventCase.Event) ? null : Workflow.GetEvent(eventCase.Event)"
+                        Events="Workflow.Events?.Where(e => e.Kind == EventKind.Consumed).ToList()"/>
+                    <input type="text" value="@eventCase.Event" placeholder="My event" title="The event of the case" class="form-control"
+                       @onchange="async e => await OnChangeAsync(c => c.Event = (string)e.Value!)" />
                 </td>
             </tr>
             <tr>
                 <td>Outcome</td>
                 <td>
                     <OutcomeEditor
-                    ForbiddenTransitions="new(){ this.state }"
-                    Outcome="eventCase.GetOutcome()"
-                    OnChange="async e => await OnChangeAsync(c => c.SetOutcome(e))"/>
+                        ForbiddenTransitions="new(){ this.state }"
+                        Outcome="eventCase.GetOutcome()"
+                        OnChange="async e => await OnChangeAsync(c => c.SetOutcome(e))"/>
                 </td>
             </tr>
         </tbody>

--- a/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/JqExpressionEditor.razor
+++ b/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/JqExpressionEditor.razor
@@ -161,6 +161,9 @@
     {
         if (string.IsNullOrWhiteSpace(this.testExpression))
             return;
+        var trimmedExpression = this.testExpression.TrimStart('$').TrimStart('{').TrimEnd('}').Trim();
+        if (string.IsNullOrWhiteSpace(trimmedExpression))
+            return;
         var json = await this.inputEditor.GetValue();
         if (this.MonacoEditorHelper.PreferedLanguage == PreferedLanguage.YAML)
         {
@@ -168,7 +171,7 @@
         }
         try
         {
-            var output = await this.JsRuntime.InvokeAsync<string>("jq.raw", json, this.testExpression);
+            var output = await this.JsRuntime.InvokeAsync<string>("jq.raw", json, trimmedExpression);
             if (this.MonacoEditorHelper.PreferedLanguage == PreferedLanguage.YAML)
             {
                 output = await this.YamlConverter.JsonToYaml(output);


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
Trimmed `${ }` from jq expressions input in jq editor