### PR TITLE
Add regular expressions support  when evaluating event mapping values

### DIFF
--- a/src/core/Synapse.Domain/Models/v1/V1CorrelationContext.cs
+++ b/src/core/Synapse.Domain/Models/v1/V1CorrelationContext.cs
@@ -16,6 +16,7 @@
  */
 
 using System.Collections.ObjectModel;
+using System.Text.RegularExpressions;
 
 namespace Synapse.Domain.Models
 {
@@ -73,7 +74,7 @@ namespace Synapse.Domain.Models
             foreach (var mapping in this.Mappings)
             {
                 if (!e.TryGetAttribute(mapping.Key, out var attributeValue)
-                    || attributeValue != mapping.Value)
+                    || !Regex.IsMatch(attributeValue, mapping.Value, RegexOptions.IgnoreCase))
                     return false;
             }
             return true;

--- a/src/core/Synapse.Domain/Models/v1/V1Event.cs
+++ b/src/core/Synapse.Domain/Models/v1/V1Event.cs
@@ -185,12 +185,9 @@ namespace Synapse.Domain.Models
             {
                 foreach (EventCorrelationDefinition correlationDefinition in eventDefinition.Correlations)
                 {
-                    if (!this.TryGetAttribute(correlationDefinition.ContextAttributeName, out string value))
-                        return false;
-                    if (string.IsNullOrWhiteSpace(correlationDefinition.ContextAttributeValue))
-                        continue;
-                    if (!Regex.IsMatch(value, correlationDefinition.ContextAttributeValue, RegexOptions.IgnoreCase))
-                        return false;
+                    if (!this.TryGetAttribute(correlationDefinition.ContextAttributeName, out string value)) return false;
+                    if (string.IsNullOrWhiteSpace(correlationDefinition.ContextAttributeValue)) continue;
+                    if (!Regex.IsMatch(value, correlationDefinition.ContextAttributeValue, RegexOptions.IgnoreCase)) return false;
                 }
             }
             return true;

--- a/src/core/Synapse.Domain/Models/v1/V1EventFilter.cs
+++ b/src/core/Synapse.Domain/Models/v1/V1EventFilter.cs
@@ -17,104 +17,101 @@
 
 using System.Text.RegularExpressions;
 
-namespace Synapse.Domain.Models
+namespace Synapse.Domain.Models;
+
+/// <summary>
+/// Represents an object used to filter events
+/// </summary>
+[DataTransferObjectType(typeof(Integration.Models.V1EventFilter))]
+public class V1EventFilter
 {
 
     /// <summary>
-    /// Represents an object used to filter events
+    /// Initializes a new <see cref="V1EventFilter"/>
     /// </summary>
-    [DataTransferObjectType(typeof(Integration.Models.V1EventFilter))]
-    public class V1EventFilter
+    protected V1EventFilter()
     {
 
-        /// <summary>
-        /// Initializes a new <see cref="V1EventFilter"/>
-        /// </summary>
-        protected V1EventFilter()
-        {
+    }
 
+    /// <summary>
+    /// Initializes a new <see cref="V1EventFilter"/>
+    /// </summary>
+    /// <param name="attributes">A <see cref="Dictionary{TKey, TValue}"/> containing the attributes to filter <see cref="V1Event"/>s by</param>
+    /// <param name="correlationMappings">A <see cref="Dictionary{TKey, TValue}"/> containing the attributes key/value to use when correlating an incoming event to the <see cref="V1Correlation"/></param>
+    public V1EventFilter(Dictionary<string, string> attributes, Dictionary<string, string> correlationMappings)
+        : this()
+    {
+        this._Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+        this._CorrelationMappings = correlationMappings ?? throw new ArgumentNullException(nameof(correlationMappings));
+    }
+
+    private Dictionary<string, string> _Attributes = new();
+    /// <summary>
+    /// Gets an <see cref="IDictionary{TKey, TValue}"/> containing the attributes to filter <see cref="V1Event"/>s by
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Attributes => this._Attributes;
+
+    private Dictionary<string, string> _CorrelationMappings = new();
+    /// <summary>
+    /// Gets an <see cref="IReadOnlyDictionary{TKey, TValue}"/> containing the attributes key/value to use when correlating an incoming event to the <see cref="V1Correlation"/>
+    /// </summary>
+    public IReadOnlyDictionary<string, string> CorrelationMappings => this._CorrelationMappings;
+
+    /// <summary>
+    /// Determines whether or not the <see cref="V1EventFilter"/> filters the specified <see cref="V1Event"/>
+    /// </summary>
+    /// <param name="e">The <see cref="V1Event"/> to filter</param>
+    /// <returns>A boolean indicating whether or not the <see cref="V1EventFilter"/> filters the specified <see cref="V1Event"/></returns>
+    public virtual bool Filters(V1Event e)
+    {
+        if (e == null)
+            throw new ArgumentNullException(nameof(e));
+        foreach (var attribute in this.Attributes)
+        {
+            if (!e.TryGetAttribute(attribute.Key, out var value))
+                return false;
+            if (!Regex.IsMatch(value, attribute.Value, RegexOptions.IgnoreCase))
+                return false;
         }
-
-        /// <summary>
-        /// Initializes a new <see cref="V1EventFilter"/>
-        /// </summary>
-        /// <param name="attributes">A <see cref="Dictionary{TKey, TValue}"/> containing the attributes to filter <see cref="V1Event"/>s by</param>
-        /// <param name="correlationMappings">A <see cref="Dictionary{TKey, TValue}"/> containing the attributes key/value to use when correlating an incoming event to the <see cref="V1Correlation"/></param>
-        public V1EventFilter(Dictionary<string, string> attributes, Dictionary<string, string> correlationMappings)
-            : this()
+        foreach (var mapping in this.CorrelationMappings)
         {
-            this._Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
-            this._CorrelationMappings = correlationMappings ?? throw new ArgumentNullException(nameof(correlationMappings));
+            if (!e.TryGetAttribute(mapping.Key, out var value))
+                return false;
+            if (!string.IsNullOrWhiteSpace(mapping.Value)
+                && !Regex.IsMatch(value, mapping.Value, RegexOptions.IgnoreCase))
+                return false;
         }
+        return true;
+    }
 
-        private Dictionary<string, string> _Attributes = new();
-        /// <summary>
-        /// Gets an <see cref="IDictionary{TKey, TValue}"/> containing the attributes to filter <see cref="V1Event"/>s by
-        /// </summary>
-        public IReadOnlyDictionary<string, string> Attributes => this._Attributes;
-
-        private Dictionary<string, string> _CorrelationMappings = new();
-        /// <summary>
-        /// Gets an <see cref="IReadOnlyDictionary{TKey, TValue}"/> containing the attributes key/value to use when correlating an incoming event to the <see cref="V1Correlation"/>
-        /// </summary>
-        public IReadOnlyDictionary<string, string> CorrelationMappings => this._CorrelationMappings;
-
-        /// <summary>
-        /// Determines whether or not the <see cref="V1EventFilter"/> filters the specified <see cref="V1Event"/>
-        /// </summary>
-        /// <param name="e">The <see cref="V1Event"/> to filter</param>
-        /// <returns>A boolean indicating whether or not the <see cref="V1EventFilter"/> filters the specified <see cref="V1Event"/></returns>
-        public virtual bool Filters(V1Event e)
+    /// <summary>
+    /// Creates a new <see cref="V1CorrelationCondition"/> used to match events defined by the specified <see cref="V1EventFilter"/>
+    /// </summary>
+    /// <param name="eventDefinition">The <see cref="EventDefinition"/> for which to build a new <see cref="V1EventFilter"/></param>
+    /// <returns>A new <see cref="V1EventFilter"/></returns>
+    public static V1EventFilter Match(EventDefinition eventDefinition)
+    {
+        if (eventDefinition == null)
+            throw new ArgumentNullException(nameof(eventDefinition));
+        var attributes = new Dictionary<string, string>();
+        if (!string.IsNullOrWhiteSpace(eventDefinition.Source))
+            attributes.Add(nameof(CloudEvent.Source).ToLower(), eventDefinition.Source);
+        if (!string.IsNullOrWhiteSpace(eventDefinition.Type))
+            attributes.Add(nameof(CloudEvent.Type).ToLower(), eventDefinition.Type);
+        var correlationMappings = new Dictionary<string, string>();
+        if (eventDefinition.Correlations != null)
         {
-            if (e == null)
-                throw new ArgumentNullException(nameof(e));
-            foreach (var attribute in this.Attributes)
+            foreach (var mapping in eventDefinition.Correlations)
             {
-                if (!e.TryGetAttribute(attribute.Key, out var value))
-                    return false;
-                if (!Regex.IsMatch(value, attribute.Value, RegexOptions.IgnoreCase))
-                    return false;
+                var value = null as string;
+                if (!string.IsNullOrWhiteSpace(mapping.ContextAttributeValue)
+                    && !mapping.ContextAttributeValue.IsRuntimeExpression())
+                    value = mapping.ContextAttributeValue;
+                correlationMappings.Add(mapping.ContextAttributeName, value!);
             }
-            foreach (var mapping in this.CorrelationMappings)
-            {
-                if (!e.TryGetAttribute(mapping.Key, out var value))
-                    return false;
-                if (!string.IsNullOrWhiteSpace(mapping.Value)
-                    && !mapping.Value.Equals(value, StringComparison.OrdinalIgnoreCase))
-                    return false;
-            }
-            return true;
         }
-
-        /// <summary>
-        /// Creates a new <see cref="V1CorrelationCondition"/> used to match events defined by the specified <see cref="V1EventFilter"/>
-        /// </summary>
-        /// <param name="eventDefinition">The <see cref="EventDefinition"/> for which to build a new <see cref="V1EventFilter"/></param>
-        /// <returns>A new <see cref="V1EventFilter"/></returns>
-        public static V1EventFilter Match(EventDefinition eventDefinition)
-        {
-            if (eventDefinition == null)
-                throw new ArgumentNullException(nameof(eventDefinition));
-            var attributes = new Dictionary<string, string>();
-            if (!string.IsNullOrWhiteSpace(eventDefinition.Source))
-                attributes.Add(nameof(CloudEvent.Source).ToLower(), eventDefinition.Source);
-            if (!string.IsNullOrWhiteSpace(eventDefinition.Type))
-                attributes.Add(nameof(CloudEvent.Type).ToLower(), eventDefinition.Type);
-            var correlationMappings = new Dictionary<string, string>();
-            if (eventDefinition.Correlations != null)
-            {
-                foreach (var mapping in eventDefinition.Correlations)
-                {
-                    var value = null as string;
-                    if (!string.IsNullOrWhiteSpace(mapping.ContextAttributeValue)
-                        && !mapping.ContextAttributeValue.IsRuntimeExpression())
-                        value = mapping.ContextAttributeValue;
-                    correlationMappings.Add(mapping.ContextAttributeName, value!);
-                }
-            }
-            return new(attributes, correlationMappings);
-        }
-
+        return new(attributes, correlationMappings);
     }
 
 }

--- a/src/core/Synapse.Integration/Models/v1/V1EventFilter.cs
+++ b/src/core/Synapse.Integration/Models/v1/V1EventFilter.cs
@@ -42,8 +42,8 @@ namespace Synapse.Integration.Models
             {
                 if (!e.TryGetAttribute(mapping.Key, out var value))
                     return false;
-                if (!string.IsNullOrWhiteSpace(mapping.Value) 
-                    && !mapping.Value.Equals(value, StringComparison.OrdinalIgnoreCase))
+                if (!string.IsNullOrWhiteSpace(mapping.Value)
+                && !Regex.IsMatch(value, mapping.Value, RegexOptions.IgnoreCase))
                     return false;
             }
             return true;


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the V1CorrelationContext, V1Event and V1EventFilter to support regular expressions when evaluating contextual mapping values
- Fixes the V1EventFilter to support regular expressions when evaluating contextual mapping values