### PR TITLE
Display action name instead of function name in the graph

### DIFF
--- a/src/dashboard/Synapse.Dashboard/Features/Shared/WorkflowDiagram/FunctionRefNodeViewModel.cs
+++ b/src/dashboard/Synapse.Dashboard/Features/Shared/WorkflowDiagram/FunctionRefNodeViewModel.cs
@@ -32,7 +32,7 @@ namespace Synapse.Dashboard
         /// <param name="action">The <see cref="ActionDefinition"/> the <see cref="FunctionRefNodeViewModel"/> represents</param>
         /// <param name="function">The <see cref="FunctionReference"/> the <see cref="FunctionRefNodeViewModel"/> represents</param>
         public FunctionRefNodeViewModel(ActionDefinition action, FunctionReference function) 
-            : base(action, function.RefName, "function-node")
+            : base(action, action.Name ?? function.RefName, "function-node")
         {
             this.Function = function;
         }


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
Used the action name if available instead of the function name in the graph.
