### PR TITLE
Updated Neuroglia packages for solution, thus resolving a bug with command line escaping in Unix when evaluating inline escaped json

### DIFF
--- a/src/apis/management/Synapse.Apis.Management.Http/Synapse.Apis.Management.Http.csproj
+++ b/src/apis/management/Synapse.Apis.Management.Http/Synapse.Apis.Management.Http.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.OData.NewtonsoftJson" Version="8.0.4" />
-    <PackageReference Include="Neuroglia.Mediation.AspNetCore" Version="2.0.3" />
+    <PackageReference Include="Neuroglia.Mediation.AspNetCore" Version="2.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.4.0" />
   </ItemGroup>

--- a/src/apps/Synapse.Server/Synapse.Server.csproj
+++ b/src/apps/Synapse.Server/Synapse.Server.csproj
@@ -32,10 +32,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.10" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
-    <PackageReference Include="Neuroglia.Caching.InMemory" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Data.Expressions.JQ" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Eventing.CloudEvents.AspNetCore" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Serialization.Json" Version="2.0.3" />
+    <PackageReference Include="Neuroglia.Caching.InMemory" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Data.Expressions.JQ" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Eventing.CloudEvents.AspNetCore" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Serialization.Json" Version="2.0.4" />
     <PackageReference Include="protobuf-net.Grpc.AspNetCore" Version="1.0.177" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
   </ItemGroup>

--- a/src/apps/Synapse.Worker/Services/Processors/InjectStateProcessor.cs
+++ b/src/apps/Synapse.Worker/Services/Processors/InjectStateProcessor.cs
@@ -45,7 +45,9 @@ namespace Synapse.Worker.Services.Processors
         protected override async Task ProcessAsync(CancellationToken cancellationToken)
         {
             var output = this.Activity.Input!.ToObject()!;
-            output = output.Merge(this.State.Data!.ToObject()!);
+            var toInject = this.State.Data!.ToObject()!;
+            toInject = await this.Context.EvaluateObjectAsync(toInject, output, cancellationToken);
+            output = output.Merge(toInject);
             await this.OnNextAsync(new V1WorkflowActivityCompletedIntegrationEvent(this.Activity.Id, output), cancellationToken);
             await this.OnCompletedAsync(cancellationToken);
         }

--- a/src/apps/Synapse.Worker/Synapse.Worker.csproj
+++ b/src/apps/Synapse.Worker/Synapse.Worker.csproj
@@ -40,9 +40,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Neuroglia.AsyncApi.Client.All" Version="2.1.0.6" />
-    <PackageReference Include="Neuroglia.Data.Expressions.JQ" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Eventing.CloudEvents" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Serialization.NewtonsoftJson" Version="2.0.3" />
+    <PackageReference Include="Neuroglia.Data.Expressions.JQ" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Eventing.CloudEvents" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Serialization.NewtonsoftJson" Version="2.0.4" />
     <PackageReference Include="protobuf-net.Grpc" Version="1.0.177" />
     <PackageReference Include="protobuf-net.Grpc.ClientFactory" Version="1.0.177" />
     <PackageReference Include="Simple.OData.Client" Version="5.26.0" />

--- a/src/core/Synapse.Application/Synapse.Application.csproj
+++ b/src/core/Synapse.Application/Synapse.Application.csproj
@@ -27,10 +27,10 @@
     <PackageReference Include="CloudNative.CloudEvents.NewtonsoftJson" Version="2.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.0.11" />
     <PackageReference Include="Microsoft.OData.ModelBuilder" Version="1.0.9" />
-    <PackageReference Include="Neuroglia.AspNetCore.JsonPatch" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Data.DistributedCache" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Data.EventSourcing" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Mediation.FluentValidation" Version="2.0.3" />
+    <PackageReference Include="Neuroglia.AspNetCore.JsonPatch" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Data.DistributedCache" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Data.EventSourcing" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Mediation.FluentValidation" Version="2.0.4" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 </Project>

--- a/src/core/Synapse.Domain/Synapse.Domain.csproj
+++ b/src/core/Synapse.Domain/Synapse.Domain.csproj
@@ -20,9 +20,9 @@
     <DebugType>embedded</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Neuroglia.AspNetCore.JsonPatch" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Data" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Data.Kubernetes" Version="2.0.3" />
+    <PackageReference Include="Neuroglia.AspNetCore.JsonPatch" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Data" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Data.Kubernetes" Version="2.0.4" />
     <PackageReference Include="Semver" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/core/Synapse.Infrastructure/Synapse.Infrastructure.csproj
+++ b/src/core/Synapse.Infrastructure/Synapse.Infrastructure.csproj
@@ -25,9 +25,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Cronos" Version="0.7.1" />
-    <PackageReference Include="Neuroglia.Data.Expressions" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Eventing.CloudEvents" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Mapping" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Mediation" Version="2.0.3" />
+    <PackageReference Include="Neuroglia.Data.Expressions" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Eventing.CloudEvents" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Mapping" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Mediation" Version="2.0.4" />
   </ItemGroup>
 </Project>

--- a/src/core/Synapse.Integration/Synapse.Integration.csproj
+++ b/src/core/Synapse.Integration/Synapse.Integration.csproj
@@ -32,10 +32,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.17" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.10" />
-    <PackageReference Include="Neuroglia.Serialization.Dynamic" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Serialization.Json" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Serialization.NewtonsoftJson" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Serialization.Protobuf" Version="2.0.3" />
+    <PackageReference Include="Neuroglia.Serialization.Dynamic" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Serialization.Json" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Serialization.NewtonsoftJson" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Serialization.Protobuf" Version="2.0.4" />
     <PackageReference Include="ServerlessWorkflow.Sdk" Version="0.8.3" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.0" />
   </ItemGroup>

--- a/src/dashboard/Synapse.Dashboard/Synapse.Dashboard.csproj
+++ b/src/dashboard/Synapse.Dashboard/Synapse.Dashboard.csproj
@@ -22,13 +22,13 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.10" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.4.1" />
-    <PackageReference Include="Neuroglia.Blazor.Dagre" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Core" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Data.Flux" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Data.Flux.ReduxDevTools" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Data.OData" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Data.Schemas" Version="2.0.3" />
-    <PackageReference Include="Neuroglia.Mapping" Version="2.0.3" />
+    <PackageReference Include="Neuroglia.Blazor.Dagre" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Core" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Data.Flux" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Data.Flux.ReduxDevTools" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Data.OData" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Data.Schemas" Version="2.0.4" />
+    <PackageReference Include="Neuroglia.Mapping" Version="2.0.4" />
     <PackageReference Include="OData.QueryBuilder" Version="2.9.7" />
     <PackageReference Include="Semver" Version="2.2.0" />
   </ItemGroup>

--- a/src/plugins/persistence/Synapse.Plugins.Persistence.EventStore/Synapse.Plugins.Persistence.EventStore.csproj
+++ b/src/plugins/persistence/Synapse.Plugins.Persistence.EventStore/Synapse.Plugins.Persistence.EventStore.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Neuroglia.Data.EventSourcing.EventStore" Version="2.0.3" />
+    <PackageReference Include="Neuroglia.Data.EventSourcing.EventStore" Version="2.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Synapse.Infrastructure\Synapse.Infrastructure.csproj">

--- a/src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB/Synapse.Plugins.Persistence.MongoDB.csproj
+++ b/src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB/Synapse.Plugins.Persistence.MongoDB.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Neuroglia.Data.MongoDB" Version="2.0.3" />
+    <PackageReference Include="Neuroglia.Data.MongoDB" Version="2.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Synapse.Infrastructure\Synapse.Infrastructure.csproj">


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Updates Neuroglia packages for solution, thus resolving a bug with command line escaping in Unix when evaluating inline escaped json
- Fixes the InjectStateProcessor to evaluate the defined data before injecting it into the state's
- Fixes the OpenApiFunctionProcessor to use the EvaluateObjectAsync IWorkflowRuntimeContext extension when building object, instead of using its own routine