### PR TITLE
Updating state references (transition/compensation) when its name has been change in the editor

### DIFF
--- a/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/StateEditor.razor
+++ b/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/StateEditor.razor
@@ -35,7 +35,7 @@
                                     <td>Name</td>
                                     <td>
                                         <input name="name" type="text" placeholder="Name" required class="form-control" value="@state.Name"
-                                               @onchange="async e => await OnPropertyChangedAsync(nameof(state.Name), s => s.Name = (string)e.Value!)" />
+                                               @onchange="async e => await OnPropertyChangedAsync(nameof(state.Name), this.PatchStateName(e))" />
                                     </td>
                                 </tr>
                                 <tr>
@@ -188,6 +188,28 @@
             if (this.state?.CompensatedBy != null && this.compensatedBy?.Name != this.state.CompensatedBy)
                 this.compensatedBy = this.Workflow.GetState(this.state.CompensatedBy);
         }
+    }
+
+    protected virtual Action<StateDefinition> PatchStateName(ChangeEventArgs e) {
+        return (StateDefinition state) => {
+            var previousName = state.Name;
+            state.Name = (string)e.Value!;
+            if (this.Workflow.StartStateName == previousName) {
+                this.Workflow.StartStateName = state.Name;
+            }
+            this.Workflow.States.ForEach(s =>
+            {
+                if (!state.UsedForCompensation) {
+                    if (s.TransitionToStateName == previousName) {
+                        s.TransitionToStateName = state.Name;
+                    }
+                }
+                else if (s.CompensatedBy == previousName) {
+                    s.CompensatedBy = state.Name;
+                }
+                // todo: update conditions when errors/timeout are implemented
+            });
+        };
     }
 
     protected virtual async Task OnStateTypeChangedAsync(StateType stateType)


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
When editing the name of a state in the editor, the referring state transition wasn't updated, leading to a broken definition. This PR intend to update those broken references.
