### PR TITLE
Replace select class "form-control" with "form-select"

### DIFF
--- a/src/dashboard/Synapse.Dashboard/Features/Shared/JsonForm/JsonFormProperty.razor
+++ b/src/dashboard/Synapse.Dashboard/Features/Shared/JsonForm/JsonFormProperty.razor
@@ -52,7 +52,7 @@
                 <label for="@Name" class="form-label">@displayName@RequiredPropertySuffix</label>
                 @if(Schema.Enum != null && Schema.Enum.Any())
                 {
-                    <select name="@Name" title="@Schema.Description" readonly="@Schema.ReadOnly" value="@Value" class="form-control" required="@IsRequired" @onchange="OnInputValueChanged">
+                    <select class="form-select" name="@Name" title="@Schema.Description" readonly="@Schema.ReadOnly" value="@Value" required="@IsRequired" @onchange="OnInputValueChanged">
                         @foreach (var option in Schema.Enum)
                         {
                             <option value="@option">@option</option>

--- a/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/ActionEditor.razor
+++ b/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/ActionEditor.razor
@@ -146,7 +146,7 @@
                                         <tr>
                                             <td>Invocation mode</td>
                                             <td>
-                                                <select value="@action.Subflow?.InvocationMode" title="Configures the subflow's invocation mode" class="form-control bg-secondary text-white"
+                                            <select value="@action.Subflow?.InvocationMode" title="Configures the subflow's invocation mode" class="form-select bg-secondary text-white"
                                                 @onchange="async e => await OnPropertyChangedAsync(nameof(action.Subflow.InvocationMode), a => { if(a.Subflow == null) a.Subflow = new(); a.Subflow.InvocationMode = EnumHelper.Parse<InvocationMode>((string)e.Value!); })"> 
                                                     @foreach(var invocationMode in Enum.GetValues<InvocationMode>())
                                                     {

--- a/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/EventEditor.razor
+++ b/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/EventEditor.razor
@@ -28,8 +28,8 @@
         <tr>
             <td>Kind</td>
             <td>
-                <select name="@nameof(evt.Kind)" required class="form-control bg-secondary text-white" 
-                @onchange="async e => await OnPropertyChanged(nameof(evt.Kind), ed => { ed.Kind = EnumHelper.Parse<EventKind>((string)e.Value!); })">
+                    <select name="@nameof(evt.Kind)" required class="form-select bg-secondary text-white"
+                        @onchange="async e => await OnPropertyChanged(nameof(evt.Kind), ed => { ed.Kind = EnumHelper.Parse<EventKind>((string)e.Value!); })">
                     @foreach (EventKind eventKind in Enum.GetValues(typeof(EventKind)))
                     {
                         var eventKindStr = @EnumHelper.Stringify(eventKind);

--- a/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/EventStateTriggerEditor.razor
+++ b/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/EventStateTriggerEditor.razor
@@ -23,7 +23,7 @@
             <tr>
                 <td>Action execution mode</td>
                 <td>
-                    <select required title="The way actions should be executed when the trigger fires" class="form-control bg-secondary text-white"
+                    <select required title="The way actions should be executed when the trigger fires" class="form-select bg-secondary text-white"
                     @onchange="async e => await OnChangeAsync(t => t.ActionMode = EnumHelper.Parse<ActionExecutionMode>((string)e.Value!))">
                         @foreach (var mode in Enum.GetValues<ActionExecutionMode>())
                         {

--- a/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/FunctionEditor.razor
+++ b/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/FunctionEditor.razor
@@ -33,7 +33,7 @@
         <tr>
             <td>Type</td>
             <td>
-                <select name="@nameof(function.Type)" required class="form-control bg-secondary text-white" 
+                <select name="@nameof(function.Type)" required class="form-select bg-secondary text-white" 
                 @onchange="async e => await OnPropertyChanged(nameof( function.Type), f => { f.Type = EnumHelper.Parse<FunctionType>((string)e.Value!); f.Operation = null!; })">
                     @foreach (FunctionType functionType in Enum.GetValues(typeof(FunctionType)))
                     {

--- a/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/GrpcOperationSelector.razor
+++ b/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/GrpcOperationSelector.razor
@@ -20,8 +20,8 @@
 @using Neuroglia.Data.Services
 @inject ISchemaRegistry SchemaRegistry
 
-<select required class="form-control" 
-@onchange="async e => OnServiceChanged((string?)e.Value)">
+<select required class="form-select"
+        @onchange="async e => OnServiceChanged((string?)e.Value)">
     @if(string.IsNullOrWhiteSpace(OperationId))
     {
         <option disabled selected value> -- select a service -- </option>
@@ -47,8 +47,8 @@
         }
     }
 </select>
-<select required class="form-control" 
-@onchange="async e => await OnOperationChangedAsync((string?)e.Value)">
+<select required class="form-select"
+        @onchange="async e => await OnOperationChangedAsync((string?)e.Value)">
     @if(string.IsNullOrWhiteSpace(OperationId))
     {
         <option disabled selected value> -- select an operation -- </option>

--- a/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/ODataEntitySetSelector.razor
+++ b/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/ODataEntitySetSelector.razor
@@ -20,8 +20,8 @@
 @using Neuroglia.Data.Services
 @inject ISchemaRegistry SchemaRegistry
 
-<select required class="form-control" 
-@onchange="async e => await OnOperationChangedAsync((string?)e.Value)">
+<select required class="form-select"
+        @onchange="async e => await OnOperationChangedAsync((string?)e.Value)">
     @if(string.IsNullOrWhiteSpace(OperationId))
     {
         <option disabled selected value> -- select an entity set -- </option>

--- a/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/OpenApiOperationSelector.razor
+++ b/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/OpenApiOperationSelector.razor
@@ -20,7 +20,7 @@
 @using Neuroglia.Data.Services
 @inject ISchemaRegistry SchemaRegistry
 
-<select required class="form-control" 
+<select required class="form-select" 
 @onchange="async e => await OnOperationChangedAsync((string?)e.Value)">
     @if(string.IsNullOrWhiteSpace(OperationId))
     {

--- a/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/StateEditors/ForEachStateEditor.razor
+++ b/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/StateEditors/ForEachStateEditor.razor
@@ -61,7 +61,7 @@
             <tr>
                 <td>Action execution mode</td>
                 <td>
-                    <select required title="The way actions should be executed when the trigger fires" class="form-control bg-secondary text-white"
+                    <select required title="The way actions should be executed when the trigger fires" class="form-select bg-secondary text-white"
                     @onchange="async e => await OnChangedAsync(s => s.Mode = EnumHelper.Parse<ActionExecutionMode>((string)e.Value!))">
                         @foreach (var mode in Enum.GetValues<ActionExecutionMode>())
                         {

--- a/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/StateEditors/OperationStateEditor.razor
+++ b/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/StateEditors/OperationStateEditor.razor
@@ -23,7 +23,7 @@
             <tr>
                 <td>Execution mode</td>
                 <td>
-                    <select required title="The mode in which the state's operations are to be executed" class="form-control bg-secondary text-white"
+                    <select required title="The mode in which the state's operations are to be executed" class="form-select bg-secondary text-white"
                     @onchange="async e => await OnChangedAsync(s => s.ActionMode = EnumHelper.Parse<ActionExecutionMode>((string)e.Value!))">
                         @foreach(var mode in Enum.GetValues<ActionExecutionMode>())
                         {

--- a/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/StateEditors/ParallelStateEditor.razor
+++ b/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/StateEditors/ParallelStateEditor.razor
@@ -23,7 +23,7 @@
             <tr>
                 <td>Completion type</td>
                 <td>
-                    <select required title="Configure the way the state completes" class="form-control bg-secondary text-white"
+                    <select required title="Configure the way the state completes" class="form-select bg-secondary text-white"
                     @onchange="async e => await OnChangedAsync(s => s.CompletionType = EnumHelper.Parse<ParallelCompletionType>((string)e.Value!))">
                         @foreach(var completionType in Enum.GetValues<ParallelCompletionType>())
                         {

--- a/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/WorkflowEditor.razor
+++ b/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/WorkflowEditor.razor
@@ -49,10 +49,16 @@
                             </td></tr>
                             <tr><td>Description</td><td><textarea type="text" placeholder="Description" value="@workflow.Description" @onchange="async e => await OnPropertyChangedAsync(nameof(workflow.Description), d => d.Description = (string)e.Value!)" class="form-control"></textarea></td></tr>
                             <tr><td>Version</td><td><input type="text" placeholder="Version" required value="@workflow.Version" @onchange="async e => await OnPropertyChangedAsync(nameof(workflow.Version), d => d.Version = (string)e.Value!)" class="form-control" /></td></tr>
-                            <tr><td>Spec version</td><td><select required @onchange="async e => await OnPropertyChangedAsync(nameof(workflow.SpecVersion), d => d.SpecVersion = (string)e.Value!)" class="form-control bg-secondary text-white">
+                            <tr>
+                                <td>Spec version</td>
+                                <td>
+                                    <select required @onchange="async e => await OnPropertyChangedAsync(nameof(workflow.SpecVersion), d => d.SpecVersion = (string)e.Value!)" class="form-select bg-secondary text-white">
                                 <option value="0.8" selected>0.8</option>
                             </select></td></tr>
-                            <tr><td>Expression language</td><td><select required @onchange="async e => await OnPropertyChangedAsync(nameof(workflow.ExpressionLanguage), d => d.ExpressionLanguage = (string)e.Value!)" class="form-control bg-secondary text-white">
+                            <tr>
+                                <td>Expression language</td>
+                                <td>
+                                    <select required @onchange="async e => await OnPropertyChangedAsync(nameof(workflow.ExpressionLanguage), d => d.ExpressionLanguage = (string)e.Value!)" class="form-select bg-secondary text-white">
                                 <option value="jq">jq</option>
                             </select></td></tr>
                             <tr><td>Keep active</td><td><input type="checkbox" placeholder="0.1.0" required value="@workflow.KeepActive" @onchange="async e => await OnPropertyChangedAsync(nameof(workflow.KeepActive), d => d.KeepActive = (bool)e.Value!)" class="form-check-input" /></td></tr>

--- a/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/WorkflowSelector.razor
+++ b/src/dashboard/Synapse.Dashboard/Features/Workflows/WorkflowEditor/WorkflowSelector.razor
@@ -21,7 +21,7 @@
 @if(workflowsByDefinitionId != null)
 {
     <div class="input-group">
-        <select value="@selectedId" class="form-control"
+        <select value="@selectedId" class="form-select"
         @onchange="async e => await OnIdChangedAsync((string)e.Value!)">
             <option disabled selected="@(string.IsNullOrWhiteSpace(selectedId))" value> -- select a workflow -- </option>
             @foreach(var workflowGroup in workflowsByDefinitionId)
@@ -29,7 +29,7 @@
                 <option value="@workflowGroup.Key" title="@workflowGroup.Value.First().Definition.Description" selected="@(workflowGroup.Key == selectedId)">@workflowGroup.Key</option>
             }
         </select>
-        <select value="@selectedVersion" class="form-control"
+        <select value="@selectedVersion" class="form-select"
         @onchange="async e => await OnVersionChangedAsync((string)e.Value!)">
             <option value="latest" selected="@(string.IsNullOrWhiteSpace(selectedVersion) || selectedVersion == "latest")" title="The latest version">latest</option>
             @if(!string.IsNullOrWhiteSpace(selectedId))


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
Continuation of #302, decorated all `select` with the `form-select` instead of `form-control` 