### PR TITLE
Fixed casing issues during serialization of Dynamic values. The casing of dynamic value property names should now be preserved.

### DIFF
--- a/src/core/Synapse.Integration/Serialization/Converters/FilteredExpandoObjectConverter.cs
+++ b/src/core/Synapse.Integration/Serialization/Converters/FilteredExpandoObjectConverter.cs
@@ -17,7 +17,6 @@
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Serialization;
 using System.Dynamic;
 
 namespace Synapse.Integration.Serialization.Converters
@@ -30,22 +29,8 @@ namespace Synapse.Integration.Serialization.Converters
         : ExpandoObjectConverter
     {
 
-        /// <summary>
-        /// Initializes a new <see cref="FilteredExpandoObjectConverter"/>
-        /// </summary>
-        /// <param name="namingStrategy">The <see cref="Newtonsoft.Json.Serialization.NamingStrategy"/> to use</param>
-        public FilteredExpandoObjectConverter(NamingStrategy namingStrategy = null)
-        {
-            this.NamingStrategy = namingStrategy ?? new CamelCaseNamingStrategy();
-        }
-
         /// <inheritdoc/>
         public override bool CanWrite => true;
-
-        /// <summary>
-        /// Gets the <see cref="Newtonsoft.Json.Serialization.NamingStrategy"/> to use
-        /// </summary>
-        protected NamingStrategy NamingStrategy { get; }
 
         /// <inheritdoc/>
         public override void WriteJson(JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer)
@@ -53,7 +38,7 @@ namespace Synapse.Integration.Serialization.Converters
             var expando = (IDictionary<string, object>)value;
             var dictionary = expando
                 .Where(p => p.Value is not null)
-                .ToDictionary(p => this.NamingStrategy.GetPropertyName(p.Key, false), p => p.Value);
+                .ToDictionary(p => p.Key, p => p.Value);
             serializer.Serialize(writer, dictionary);
         }
 


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Fixes casing issues during serialization of Dynamic values. The casing of dynamic value property names should now be preserved.

Fixes #192