### PR TITLE
Removed unused and unsafe dependency

### DIFF
--- a/src/dashboard/Synapse.Dashboard/wwwroot/lib/js-yaml/package.json
+++ b/src/dashboard/Synapse.Dashboard/wwwroot/lib/js-yaml/package.json
@@ -55,7 +55,6 @@
     "codemirror": "^5.13.4",
     "eslint": "^7.0.0",
     "fast-check": "^2.8.0",
-    "gh-pages": "^3.1.0",
     "mocha": "^8.2.1",
     "nyc": "^15.1.0",
     "rollup": "^2.34.1",


### PR DESCRIPTION
Removed `gh-pages` from js-yaml library package.json to fix https://github.com/serverlessworkflow/synapse/security/dependabot/2