### PR TITLE
Fixed the OAuth2TokenManager by disabling HTTPS requirements when performing OIDC discovery requests

### DIFF
--- a/deployments/docker-compose/docker-compose.build.yml
+++ b/deployments/docker-compose/docker-compose.build.yml
@@ -13,6 +13,7 @@ services:
       CONNECTIONSTRINGS__REDIS: ${GARNET_URI}
       SYNAPSE_DASHBOARD_SERVE: true
       SYNAPSE_API_AUTH_TOKEN_FILE: /app/tokens.yaml
+      SYNAPSE_API_JWT_AUTHORITY: http://api:8080
     volumes:
       - ./config/tokens.yaml:/app/tokens.yaml
     ports:

--- a/deployments/docker-compose/docker-compose.yml
+++ b/deployments/docker-compose/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       CONNECTIONSTRINGS__REDIS: ${GARNET_URI}
       SYNAPSE_DASHBOARD_SERVE: true
       SYNAPSE_API_AUTH_TOKEN_FILE: /app/tokens.yaml
-      SYNAPSE_API_AUTH_AUTHORITY: http://api:8080
+      SYNAPSE_API_JWT_AUTHORITY: http://api:8080
     volumes:
       - ./config/tokens.yaml:/app/tokens.yaml
     ports:

--- a/src/api/Synapse.Api.Server/Program.cs
+++ b/src/api/Synapse.Api.Server/Program.cs
@@ -18,7 +18,7 @@ var builder = WebApplication.CreateBuilder(args);
 var applicationOptions = new ApiServerOptions();
 builder.Configuration.Bind(applicationOptions);
 if (applicationOptions.Authentication.Tokens.Count < 1) throw new Exception("The Synapse API server requires that at least one static user token be configured");
-var authority = builder.Environment.RunsInDocker() || builder.Environment.RunsInKubernetes() ? Environment.GetEnvironmentVariable("SYNAPSE_API_AUTH_AUTHORITY") : null;
+var authority = builder.Environment.RunsInDocker() || builder.Environment.RunsInKubernetes() ? Environment.GetEnvironmentVariable("SYNAPSE_API_JWT_AUTHORITY") : null;
 
 builder.Services.Configure<ApiServerOptions>(builder.Configuration);
 builder.Services.AddResponseCompression();


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Fixed the OAuth2TokenManager by disabling HTTPS requirements when performing OIDC discovery requests

Closes #379 