### PR TITLE
Fix the Operator's RunnerDefinition by making its `Certificates` property optional

### DIFF
--- a/src/core/Synapse.Core/Resources/RunnerDefinition.cs
+++ b/src/core/Synapse.Core/Resources/RunnerDefinition.cs
@@ -43,8 +43,7 @@ public record RunnerDefinition
     /// <summary>
     /// Gets/sets the endpoint that references the base address and authentication policy for the Synapse API used by runners
     /// </summary>
-    [Required]
     [DataMember(Order = 3, Name = "certificates"), JsonPropertyOrder(3), JsonPropertyName("certificates"), YamlMember(Order = 3, Alias = "certificates")]
-    public virtual CertificateValidationStrategyDefinition Certificates { get; set; } = null!;
+    public virtual CertificateValidationStrategyDefinition? Certificates { get; set; }
     
 }


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the Operator's RunnerDefinition by making its `Certificates` property optional

Closes #382 