### PR TITLE
Fix `WorkflowCompletedEventV1` by adding a new `output` property

### DIFF
--- a/src/api/Synapse.Api.Application/Commands/Resources/CreateResourceCommand.cs
+++ b/src/api/Synapse.Api.Application/Commands/Resources/CreateResourceCommand.cs
@@ -79,7 +79,7 @@ public class CreateResourceCommandHandler(IResourceRepository repository)
     /// <inheritdoc/>
     public virtual async Task<IOperationResult<IResource>> HandleAsync(CreateResourceCommand command, CancellationToken cancellationToken)
     {
-        if (command.Resource.GetName().Trim().EndsWith('-')) command.Resource.Metadata.Name = $"{command.Resource.GetName().Trim()}{Guid.NewGuid().ToString("N")[..15]}";
+        if (command.Resource.GetName().Trim().EndsWith('-')) command.Resource.Metadata.Name = $"{command.Resource.GetName().Trim()}{Guid.NewGuid().ToString("N")[..12]}";
         var resource = await repository.AddAsync(command.Resource, command.Group, command.Version, command.Plural, command.DryRun, cancellationToken);
         return new OperationResult<IResource>((int)HttpStatusCode.Created, resource);
     }

--- a/src/api/Synapse.Api.Application/Commands/Resources/Generic/CreateResourceCommand.cs
+++ b/src/api/Synapse.Api.Application/Commands/Resources/Generic/CreateResourceCommand.cs
@@ -46,7 +46,7 @@ public class CreateResourceCommandHandler<TResource>(IResourceRepository reposit
     /// <inheritdoc/>
     public virtual async Task<IOperationResult<TResource>> HandleAsync(CreateResourceCommand<TResource> command, CancellationToken cancellationToken)
     {
-        if (command.Resource.GetName().Trim().EndsWith('-')) command.Resource.Metadata.Name = $"{command.Resource.GetName().Trim()}{Guid.NewGuid().ToString("N")[..15]}";
+        if (command.Resource.GetName().Trim().EndsWith('-')) command.Resource.Metadata.Name = $"{command.Resource.GetName().Trim()}{Guid.NewGuid().ToString("N")[..12]}";
         var resource = await repository.AddAsync(command.Resource, false, cancellationToken).ConfigureAwait(false);
         return new OperationResult<TResource>((int)HttpStatusCode.Created, resource);
     }

--- a/src/core/Synapse.Core.Infrastructure.Containers.Docker/DockerContainerPlatform.cs
+++ b/src/core/Synapse.Core.Infrastructure.Containers.Docker/DockerContainerPlatform.cs
@@ -93,6 +93,7 @@ public class DockerContainerPlatform(ILogger<DockerContainerPlatform> logger, IH
         }
         var parameters = new CreateContainerParameters()
         {
+            Name = $"{System.Environment.GetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.Runner.Name)}-{definition.Image}-{Guid.NewGuid().ToString("N")[..6].ToLowerInvariant()}",
             Image = definition.Image,
             Cmd = string.IsNullOrWhiteSpace(definition.Command) ? null : ["/bin/sh", "-c", definition.Command],
             Env = definition.Environment?.Select(e => $"{e.Key}={e.Value}").ToList(),

--- a/src/core/Synapse.Core.Infrastructure.Containers.Kubernetes/KubernetesContainer.cs
+++ b/src/core/Synapse.Core.Infrastructure.Containers.Kubernetes/KubernetesContainer.cs
@@ -107,10 +107,10 @@ public class KubernetesContainer(V1Pod pod, ILogger<KubernetesContainer> logger,
     /// <inheritdoc/>
     public virtual async Task WaitForExitAsync(CancellationToken cancellationToken = default)
     {
-        var response = this.Kubernetes.CoreV1.ListNamespacedPodWithHttpMessagesAsync(this.Pod.Namespace(), fieldSelector: $"metadata.name={Pod.Name()}", cancellationToken: cancellationToken);
+        var response = this.Kubernetes.CoreV1.ListNamespacedPodWithHttpMessagesAsync(this.Pod.Namespace(), fieldSelector: $"metadata.name={Pod.Name()}", watch: true, cancellationToken: cancellationToken);
         await foreach (var (_, item) in response.WatchAsync<V1Pod, V1PodList>(cancellationToken: cancellationToken).ConfigureAwait(false))
         {
-            if (item.Status.Phase != "Succeeded" || item.Status.Phase != "Failed") continue;
+            if (item.Status.Phase != "Succeeded" && item.Status.Phase != "Failed") continue;
             var containerStatus = item.Status.ContainerStatuses.FirstOrDefault();
             this.ExitCode = containerStatus?.State.Terminated?.ExitCode ?? -1;
             break;

--- a/src/core/Synapse.Core.Infrastructure.Containers.Kubernetes/KubernetesContainerPlatform.cs
+++ b/src/core/Synapse.Core.Infrastructure.Containers.Kubernetes/KubernetesContainerPlatform.cs
@@ -77,17 +77,22 @@ public class KubernetesContainerPlatform(IServiceProvider serviceProvider, ILogg
         if (this.Kubernetes == null) throw new NullReferenceException("The KubernetesContainerPlatform has not been properly initialized");
         var pod = new V1Pod()
         {
+            Metadata = new()
+            {
+                NamespaceProperty = $"{System.Environment.GetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.Runner.Namespace)}",
+                Name = $"{System.Environment.GetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.Runner.Name)}-{definition.Image}-{Guid.NewGuid().ToString("N")[..6].ToLowerInvariant()}"
+            },
             Spec = new()
             {
+                RestartPolicy = "Never",
                 Containers = 
                 [
-                    new()
+                    new(definition.Image)
                     {
                         Image = definition.Image,
                         ImagePullPolicy = this.Options.ImagePullPolicy,
                         Command = string.IsNullOrWhiteSpace(definition.Command) ? null : ["/bin/sh", "-c", definition.Command],
-                        Env = definition.Environment?.Select(e => new V1EnvVar(e.Key, e.Value)).ToList(),
-                        RestartPolicy = "Never"
+                        Env = definition.Environment?.Select(e => new V1EnvVar(e.Key, e.Value)).ToList()
                     }
                 ]
             }

--- a/src/core/Synapse.Core/Events/Workflows/WorkflowCompletedEventV1.cs
+++ b/src/core/Synapse.Core/Events/Workflows/WorkflowCompletedEventV1.cs
@@ -32,4 +32,10 @@ public record WorkflowCompletedEventV1
     [DataMember(Name = "completedAt", Order = 2), JsonPropertyName("completedAt"), JsonPropertyOrder(2), YamlMember(Alias = "completedAt", Order = 2)]
     public DateTimeOffset CompletedAt { get; set; } = DateTimeOffset.Now;
 
+    /// <summary>
+    /// Gets/sets the workflow instance's output
+    /// </summary>
+    [DataMember(Name = "output", Order = 3), JsonPropertyName("output"), JsonPropertyOrder(3), YamlMember(Alias = "output", Order = 3)]
+    public object? Output { get; set; }
+
 }

--- a/src/core/Synapse.Core/Resources/Document.cs
+++ b/src/core/Synapse.Core/Resources/Document.cs
@@ -23,7 +23,7 @@ public record Document
 
     /// <inheritdoc/>
     [DataMember(Name = "id", Order = 1), JsonPropertyName("id"), JsonPropertyOrder(1), YamlMember(Alias = "id", Order = 1)]
-    public string Id { get; set; } = Guid.NewGuid().ToString("N")[..15];
+    public string Id { get; set; } = Guid.NewGuid().ToString("N")[..12];
 
     /// <summary>
     /// Gets/sets the document's name

--- a/src/core/Synapse.Core/Resources/NativeRuntimeConfiguration.cs
+++ b/src/core/Synapse.Core/Resources/NativeRuntimeConfiguration.cs
@@ -28,6 +28,10 @@ public record NativeRuntimeConfiguration
     /// Gets the default path to the runner executable file
     /// </summary>
     public const string DefaultExecutable = "Synapse.Runner";
+    /// <summary>
+    /// Gets the default path to the directory that contains the secrets made available to runners
+    /// </summary>
+    public static readonly string DefaultSecretsDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".synapse", "secrets");
 
     /// <summary>
     /// Initializes a new <see cref="NativeRuntimeConfiguration"/>
@@ -47,6 +51,8 @@ public record NativeRuntimeConfiguration
             if (!File.Exists(filePath)) throw new FileNotFoundException("The runner executable file does not exist or cannot be found", filePath);
             this.Executable = env;
         }
+        env = Environment.GetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.Runtime.Native.SecretsDirectory);
+        if (!string.IsNullOrWhiteSpace(env)) this.SecretsDirectory = env;
     }
 
     /// <summary>
@@ -61,5 +67,10 @@ public record NativeRuntimeConfiguration
     [DataMember(Order = 2, Name = "executable"), JsonPropertyOrder(2), JsonPropertyName("executable"), YamlMember(Order = 2, Alias = "executable")]
     public virtual string Executable { get; set; } = DefaultExecutable;
 
+    /// <summary>
+    /// Gets/sets the path to the directory that contains the secrets made available to runners
+    /// </summary>
+    [DataMember(Order = 3, Name = "secretsDirectory"), JsonPropertyOrder(3), JsonPropertyName("secretsDirectory"), YamlMember(Order = 3, Alias = "secretsDirectory")]
+    public virtual string SecretsDirectory { get; set; } = DefaultSecretsDirectory;
 
 }

--- a/src/core/Synapse.Core/Resources/TaskInstance.cs
+++ b/src/core/Synapse.Core/Resources/TaskInstance.cs
@@ -24,7 +24,7 @@ public record TaskInstance
     /// Gets the task's id
     /// </summary>
     [DataMember(Name = "id", Order = 1), JsonPropertyName("id"), JsonPropertyOrder(1), YamlMember(Alias = "id", Order = 1)]
-    public virtual string Id { get; set; } = Guid.NewGuid().ToString("N")[..15];
+    public virtual string Id { get; set; } = Guid.NewGuid().ToString("N")[..12];
 
     /// <summary>
     /// Gets the task's name, if any

--- a/src/core/Synapse.Core/Synapse.Core.csproj
+++ b/src/core/Synapse.Core/Synapse.Core.csproj
@@ -15,6 +15,7 @@
 	<Copyright>Copyright © 2024-Present The Synapse Authors. All Rights Reserved.</Copyright>
 	<RepositoryUrl>https://github.com/serverlessworkflow/synapse</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
+	<PackageId>Synapse</PackageId>
 	<PackageProjectUrl>https://github.com/serverlessworkflow/synapse</PackageProjectUrl>
 	<PackageTags>synapse core</PackageTags>
 	<IsPackable>true</IsPackable>

--- a/src/core/Synapse.Core/SynapseDefaults.cs
+++ b/src/core/Synapse.Core/SynapseDefaults.cs
@@ -562,6 +562,14 @@ public static class SynapseDefaults
             /// Gets the environment variable used to configure whether or not runners should publish lifecycle events
             /// </summary>
             public const string LifecycleEvents = Prefix + "LIFECYCLE_EVENTS";
+            /// <summary>
+            /// Gets the environment variable used to configure the runner's namespace
+            /// </summary>
+            public const string Namespace = Prefix + "NAMESPACE";
+            /// <summary>
+            /// Gets the environment variable used to configure the runner's name
+            /// </summary>
+            public const string Name = Prefix + "NAME";
 
         }
 
@@ -740,6 +748,10 @@ public static class SynapseDefaults
                 /// Gets the environment variable used to configure the path to the runner's executable file
                 /// </summary>
                 public const string Executable = Prefix + "EXECUTABLE";
+                /// <summary>
+                /// Gets the environment variable used to configure the directory that contains the secrets made available to runners
+                /// </summary>
+                public const string SecretsDirectory = Prefix + "SECRETS_DIRECTORY";
 
             }
 

--- a/src/correlator/Synapse.Correlator/Services/CorrelationHandler.cs
+++ b/src/correlator/Synapse.Correlator/Services/CorrelationHandler.cs
@@ -121,7 +121,7 @@ public class CorrelationHandler(ILogger<CorrelationHandler> logger, IResourceRep
                         this.Logger.LogInformation("Creating a new correlation context...");
                         context = new CorrelationContext()
                         {
-                            Id = Guid.NewGuid().ToString("N")[..15],
+                            Id = Guid.NewGuid().ToString("N")[..12],
                             Events = [new(filter.Key, e)],
                             Keys = CorrelationKeys == null ? new() : new(CorrelationKeys)
                         };
@@ -150,7 +150,7 @@ public class CorrelationHandler(ILogger<CorrelationHandler> logger, IResourceRep
                         this.Logger.LogInformation("Creating a new correlation context...");
                         context = new CorrelationContext()
                         {
-                            Id = Guid.NewGuid().ToString("N")[..15],
+                            Id = Guid.NewGuid().ToString("N")[..12],
                             Events = [new(filter.Key, e)],
                             Keys = CorrelationKeys == null ? new() : new(CorrelationKeys)
                         };

--- a/src/runner/Synapse.Runner/Services/Executors/ContainerProcessExecutor.cs
+++ b/src/runner/Synapse.Runner/Services/Executors/ContainerProcessExecutor.cs
@@ -56,7 +56,7 @@ public class ContainerProcessExecutor(IServiceProvider serviceProvider, ILogger<
         {
             await this.Container!.StartAsync(cancellationToken).ConfigureAwait(false);
             await this.Container.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-            var standardOutput = (this.Container.StandardOutput == null ? null : await this.Container.StandardOutput.ReadToEndAsync(cancellationToken).ConfigureAwait(false))?.Trim()[8..];
+            var standardOutput = (this.Container.StandardOutput == null ? null : await this.Container.StandardOutput.ReadToEndAsync(cancellationToken).ConfigureAwait(false))?.Trim();
             var standardError = (this.Container.StandardError == null ? null : await this.Container.StandardError.ReadToEndAsync(cancellationToken).ConfigureAwait(false))?.Trim();
             var result = standardOutput; //todo: do something with return data encoding (ex: plain-text, json);
             await this.SetResultAsync(result, this.Task.Definition.Then, cancellationToken).ConfigureAwait(false);

--- a/src/runner/Synapse.Runner/Services/SecretsManager.cs
+++ b/src/runner/Synapse.Runner/Services/SecretsManager.cs
@@ -51,8 +51,8 @@ public class SecretsManager(ILogger<SecretsManager> logger, ISerializerProvider 
         try
         {
             var path = string.IsNullOrWhiteSpace(this.Options.Secrets.Directory)
-            ? RunnerSecretsOptions.DefaultDirectory
-            : this.Options.Secrets.Directory;
+                ? RunnerSecretsOptions.DefaultDirectory
+                : this.Options.Secrets.Directory;
             var directory = new DirectoryInfo(path);
             if (!directory.Exists) directory.Create();
             foreach (var file in directory.GetFiles())
@@ -72,14 +72,14 @@ public class SecretsManager(ILogger<SecretsManager> logger, ISerializerProvider 
                 }
                 catch (Exception ex)
                 {
-                    this.Logger.LogWarning("Skipped loading secret '{secretFile}': an exception occurred while deserializing the secret object: {ex}", file.Name, ex.ToString());
+                    this.Logger.LogWarning("Skipped loading secret '{secretFile}': an exception occurred while deserializing the secret object: {ex}", file.Name, ex.Message);
                     continue;
                 }
             }
         }
         catch(Exception ex)
         {
-            this.Logger.LogWarning("Failed to load secrets because there are none or because they are improperly configured. Error: {ex}", ex);
+            this.Logger.LogWarning("Failed to load secrets because there are none or because they are improperly configured. Error: {ex}", ex.Message);
         }
         return Task.CompletedTask;
     }

--- a/src/runner/Synapse.Runner/Services/WorkflowExecutionContext.cs
+++ b/src/runner/Synapse.Runner/Services/WorkflowExecutionContext.cs
@@ -577,7 +577,8 @@ public class WorkflowExecutionContext(IServiceProvider services, IExpressionEval
                 Data = new WorkflowCompletedEventV1()
                 {
                     Name = this.Instance.GetQualifiedName(),
-                    CompletedAt = run?.EndedAt ?? DateTimeOffset.Now
+                    CompletedAt = run?.EndedAt ?? DateTimeOffset.Now,
+                    Output = this.Output
                 }
             }, cancellationToken).ConfigureAwait(false);
             await this.Api.Events.PublishAsync(new CloudEvent()

--- a/src/runtime/Synapse.Runtime.Docker/Services/DockerRuntime.cs
+++ b/src/runtime/Synapse.Runtime.Docker/Services/DockerRuntime.cs
@@ -78,6 +78,8 @@ public class DockerRuntime(IServiceProvider serviceProvider, ILoggerFactory logg
             this.Logger.LogDebug("Creating a new Docker container for workflow instance '{workflowInstance}'...", workflowInstance.GetQualifiedName());
             if (this.Docker == null) await this.InitializeAsync(cancellationToken).ConfigureAwait(false);
             var container = this.Runner.Runtime.Docker!.ContainerTemplate.Clone()!;
+            container.SetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.Runner.Namespace, workflowInstance.GetNamespace()!);
+            container.SetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.Runner.Name, $"{workflowInstance.GetName()}-{Guid.NewGuid().ToString("N")[..12].ToLowerInvariant()}");
             container.SetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.Api.Uri, this.Runner.Api.Uri.OriginalString);
             container.SetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.Runner.ContainerPlatform, this.Runner.ContainerPlatform);
             container.SetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.Runner.LifecycleEvents, (this.Runner.PublishLifecycleEvents ?? true).ToString());
@@ -111,7 +113,7 @@ public class DockerRuntime(IServiceProvider serviceProvider, ILoggerFactory logg
             ];
             var parameters = new CreateContainerParameters(container)
             {
-                Name = $"{workflowInstance.GetQualifiedName()}-{Guid.NewGuid().ToString("N")[..15].ToLowerInvariant()}",
+                Name = $"{workflowInstance.GetQualifiedName()}-{Guid.NewGuid().ToString("N")[..12].ToLowerInvariant()}",
                 HostConfig = hostConfig
             };
             var result = await this.Docker!.Containers.CreateContainerAsync(parameters, cancellationToken).ConfigureAwait(false);

--- a/src/runtime/Synapse.Runtime.Kubernetes/Services/KubernetesWorkflowProcess.cs
+++ b/src/runtime/Synapse.Runtime.Kubernetes/Services/KubernetesWorkflowProcess.cs
@@ -123,10 +123,10 @@ public class KubernetesWorkflowProcess(V1Pod pod, ILogger<KubernetesWorkflowProc
     /// <inheritdoc/>
     public virtual async Task WaitForExitAsync(CancellationToken cancellationToken = default)
     {
-        var response = this.Kubernetes.CoreV1.ListNamespacedPodWithHttpMessagesAsync(this.Pod.Namespace(), fieldSelector: $"metadata.name={Pod.Name()}", cancellationToken: cancellationToken);
+        var response = this.Kubernetes.CoreV1.ListNamespacedPodWithHttpMessagesAsync(this.Pod.Namespace(), fieldSelector: $"metadata.name={Pod.Name()}", watch: true, cancellationToken: cancellationToken);
         await foreach (var (_, item) in response.WatchAsync<V1Pod, V1PodList>(cancellationToken: cancellationToken).ConfigureAwait(false))
         {
-            if (item.Status.Phase != "Succeeded" || item.Status.Phase != "Failed") continue;
+            if (item.Status.Phase != "Succeeded" && item.Status.Phase != "Failed") continue;
             var containerStatus = item.Status.ContainerStatuses.FirstOrDefault();
             this._exitCode = containerStatus?.State.Terminated?.ExitCode ?? -1;
             break;

--- a/src/runtime/Synapse.Runtime.Native/Services/NativeRuntime.cs
+++ b/src/runtime/Synapse.Runtime.Native/Services/NativeRuntime.cs
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 using Neuroglia.Data.Infrastructure.ResourceOriented;
+using System.ComponentModel;
 
 namespace Synapse.Runtime.Services;
 
@@ -70,12 +71,15 @@ public class NativeRuntime(ILoggerFactory loggerFactory, IHostEnvironment enviro
             CreateNoWindow = true,
             UseShellExecute = false
         };
-        startInfo.Environment.Add(SynapseDefaults.EnvironmentVariables.Api.Uri, this.Options.Api.Uri.OriginalString);
-        startInfo.Environment.Add(SynapseDefaults.EnvironmentVariables.Workflow.Instance, workflowInstance.GetQualifiedName());
-        startInfo.Environment[SynapseDefaults.EnvironmentVariables.ServiceAccount.Name] = serviceAccount.GetQualifiedName();
-        startInfo.Environment[SynapseDefaults.EnvironmentVariables.ServiceAccount.Key] = serviceAccount.Spec.Key;
+        startInfo.Environment[SynapseDefaults.EnvironmentVariables.Runner.Namespace] = workflowInstance.GetNamespace()!;
+        startInfo.Environment[SynapseDefaults.EnvironmentVariables.Runner.Name] = $"{workflowInstance.GetName()}-{Guid.NewGuid().ToString("N")[..12].ToLowerInvariant()}";
+        startInfo.Environment[SynapseDefaults.EnvironmentVariables.Api.Uri] = this.Options.Api.Uri.OriginalString;
         startInfo.Environment[SynapseDefaults.EnvironmentVariables.Runner.ContainerPlatform] = this.Options.ContainerPlatform;
         startInfo.Environment[SynapseDefaults.EnvironmentVariables.Runner.LifecycleEvents] = (this.Options.PublishLifecycleEvents ?? true).ToString();
+        startInfo.Environment[SynapseDefaults.EnvironmentVariables.Secrets.Directory] = this.Options.Runtime.Native.SecretsDirectory;
+        startInfo.Environment[SynapseDefaults.EnvironmentVariables.ServiceAccount.Name] = serviceAccount.GetQualifiedName();
+        startInfo.Environment[SynapseDefaults.EnvironmentVariables.ServiceAccount.Key] = serviceAccount.Spec.Key;
+        startInfo.Environment[SynapseDefaults.EnvironmentVariables.Workflow.Instance] = workflowInstance.GetQualifiedName();
         if (this.Options.Certificates?.Validate == false) startInfo.Environment.Add(SynapseDefaults.EnvironmentVariables.SkipCertificateValidation, "true");
         var process = new Process()
         {

--- a/tests/Synapse.UnitTests/Cases/Conformance/ConformanceTestsBase.cs
+++ b/tests/Synapse.UnitTests/Cases/Conformance/ConformanceTestsBase.cs
@@ -152,7 +152,7 @@ public abstract class ConformanceTestsBase
             Metadata = new()
             {
                 Namespace = Definition.Document.Namespace,
-                Name = $"{Definition.Document.Name}-{Guid.NewGuid().ToString("N")[..15]}"
+                Name = $"{Definition.Document.Name}-{Guid.NewGuid().ToString("N")[..12]}"
             },
             Spec = new()
             {

--- a/tests/Synapse.UnitTests/Services/MockWorkflowExecutionContextFactory.cs
+++ b/tests/Synapse.UnitTests/Services/MockWorkflowExecutionContextFactory.cs
@@ -46,7 +46,7 @@ internal static class MockWorkflowExecutionContextFactory
         {
             Metadata = new()
             {
-                Name = $"{workflow.GetName()}-{Guid.NewGuid().ToString("N")[..15]}",
+                Name = $"{workflow.GetName()}-{Guid.NewGuid().ToString("N")[..12]}",
                 Namespace = workflow.GetNamespace()
             },
             Spec = new()


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the `WorkflowCompletedEventV1` by adding a new `output` property
- Fixes all runtimes to set both the runner's `NAMESPACE` and `NAME` environment variables
- Fixes all container platforms to name spawned containers after both the runner and their image
- Fixes the ContainerTaskExecutor by removing output truncation when using Kubernetes
- Fixes the KubernetesContainer by fixing the WaitForExit method
- Changed the Nuget package name to Synapse to avoid collision with a package from another company

Closes #396 