### PR TITLE
Fixed the operator to use IOptionsMonitor instead of IOptions to access the OperatorOptions

### DIFF
--- a/src/operator/Synapse.Operator/Program.cs
+++ b/src/operator/Synapse.Operator/Program.cs
@@ -30,7 +30,7 @@ var builder = Host.CreateDefaultBuilder()
         services.Configure<OperatorOptions>(context.Configuration);
         services.AddSingleton(provider =>
         {
-            var options = provider.GetRequiredService<IOptions<OperatorOptions>>().Value;
+            var options = provider.GetRequiredService<IOptionsMonitor<OperatorOptions>>().CurrentValue;
             return Options.Create(options.Runner);
         });
         services.AddLogging(builder =>


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the operator to use IOptionsMonitor instead of IOptions to access the OperatorOptions, thus making sure the proper resource-based configuration