### PR TITLE
Fixed the way both the `HttpCallProcessor` and `OpenApiCallProcessor` evaluate endpoint URIs

### DIFF
--- a/src/runner/Synapse.Runner/Services/Executors/HttpCallExecutor.cs
+++ b/src/runner/Synapse.Runner/Services/Executors/HttpCallExecutor.cs
@@ -131,7 +131,7 @@ public class HttpCallExecutor(IServiceProvider serviceProvider, ILogger<HttpCall
             }
         }
         var uri = StringFormatter.NamedFormat(this.Http.EndpointUri.OriginalString, this.Task.Input.ToDictionary());
-        if (uri.IsRuntimeExpression()) uri = await this.Task.Workflow.Expressions.EvaluateAsync<string>(uri, this.Task.Input, this.Task.Arguments, cancellationToken).ConfigureAwait(false);
+        if (uri.IsRuntimeExpression()) uri = await this.Task.Workflow.Expressions.EvaluateAsync<string>(uri, this.Task.Input, this.GetExpressionEvaluationArguments(), cancellationToken).ConfigureAwait(false);
         using var request = new HttpRequestMessage(new HttpMethod(this.Http.Method), uri) { Content = requestContent };
         using var response = await this.HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode) //todo: could be configurable on HTTP call?

--- a/src/runner/Synapse.Runner/Services/Executors/OpenApiCallExecutor.cs
+++ b/src/runner/Synapse.Runner/Services/Executors/OpenApiCallExecutor.cs
@@ -110,7 +110,7 @@ public class OpenApiCallExecutor(IServiceProvider serviceProvider, ILogger<OpenA
         using var httpClient = this.HttpClientFactory.CreateClient();
         await httpClient.ConfigureAuthenticationAsync(this.Task.Workflow.Definition, this.OpenApi.Document.Endpoint.Authentication, this.ServiceProvider, cancellationToken).ConfigureAwait(false);
         var uri = StringFormatter.NamedFormat(this.OpenApi.Document.EndpointUri.OriginalString, this.Task.Input.ToDictionary());
-        if (uri.IsRuntimeExpression()) uri = await this.Task.Workflow.Expressions.EvaluateAsync<string>(uri, this.Task.Input, this.Task.Arguments, cancellationToken).ConfigureAwait(false);
+        if (uri.IsRuntimeExpression()) uri = await this.Task.Workflow.Expressions.EvaluateAsync<string>(uri, this.Task.Input, this.GetExpressionEvaluationArguments(), cancellationToken).ConfigureAwait(false);
         using var request = new HttpRequestMessage(HttpMethod.Get, uri);
         using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

* Fixes the way both the `HttpCallProcessor` and `OpenApiCallProcessor` evaluate endpoint URIs, by retrieving the contextual expression evaluation arguments instead of the task's