### PR TITLE
Publish emitted events on internal bus

### DIFF
--- a/src/api/Synapse.Api.Application/Synapse.Api.Application.csproj
+++ b/src/api/Synapse.Api.Application/Synapse.Api.Application.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha2</VersionSuffix>
+	<VersionSuffix>alpha3</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/api/Synapse.Api.Client.Core/Synapse.Api.Client.Core.csproj
+++ b/src/api/Synapse.Api.Client.Core/Synapse.Api.Client.Core.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha2</VersionSuffix>
+	<VersionSuffix>alpha3</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/api/Synapse.Api.Client.Http/Synapse.Api.Client.Http.csproj
+++ b/src/api/Synapse.Api.Client.Http/Synapse.Api.Client.Http.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha2</VersionSuffix>
+	<VersionSuffix>alpha3</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/api/Synapse.Api.Http/Synapse.Api.Http.csproj
+++ b/src/api/Synapse.Api.Http/Synapse.Api.Http.csproj
@@ -8,7 +8,7 @@
 	<OutputType>Library</OutputType>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha2</VersionSuffix>
+	<VersionSuffix>alpha3</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/api/Synapse.Api.Server/Synapse.Api.Server.csproj
+++ b/src/api/Synapse.Api.Server/Synapse.Api.Server.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha2</VersionSuffix>
+	<VersionSuffix>alpha3</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/cli/Synapse.Cli/Synapse.Cli.csproj
+++ b/src/cli/Synapse.Cli/Synapse.Cli.csproj
@@ -8,7 +8,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha2</VersionSuffix>
+	<VersionSuffix>alpha3</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/core/Synapse.Core.Infrastructure.Containers.Docker/Synapse.Core.Infrastructure.Containers.Docker.csproj
+++ b/src/core/Synapse.Core.Infrastructure.Containers.Docker/Synapse.Core.Infrastructure.Containers.Docker.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha2</VersionSuffix>
+	<VersionSuffix>alpha3</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/core/Synapse.Core.Infrastructure.Containers.Kubernetes/Synapse.Core.Infrastructure.Containers.Kubernetes.csproj
+++ b/src/core/Synapse.Core.Infrastructure.Containers.Kubernetes/Synapse.Core.Infrastructure.Containers.Kubernetes.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha2</VersionSuffix>
+	<VersionSuffix>alpha3</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/core/Synapse.Core.Infrastructure/Services/DatabaseInitializer.cs
+++ b/src/core/Synapse.Core.Infrastructure/Services/DatabaseInitializer.cs
@@ -57,7 +57,7 @@ public class DatabaseInitializer(ILoggerFactory loggerFactory, IServiceProvider 
             }, false, cancellationToken).ConfigureAwait(false);
             await this.Database.InitializeAsync(cancellationToken);
         }
-        catch (ProblemDetailsException ex) when (ex.Problem.Status == (int)HttpStatusCode.Conflict || (ex.Problem.Status == (int)HttpStatusCode.BadRequest && ex.Problem.Title == "Conflict")) { continue; }
+        catch (ProblemDetailsException ex) when (ex.Problem.Status == (int)HttpStatusCode.Conflict || (ex.Problem.Status == (int)HttpStatusCode.BadRequest && ex.Problem.Title == "Conflict")) { }
     }
 
 }

--- a/src/core/Synapse.Core.Infrastructure/Services/DatabaseInitializer.cs
+++ b/src/core/Synapse.Core.Infrastructure/Services/DatabaseInitializer.cs
@@ -12,8 +12,10 @@
 // limitations under the License.
 
 using Microsoft.Extensions.Logging;
+using Neuroglia;
 using Neuroglia.Data.Infrastructure.ResourceOriented;
 using Synapse.Resources;
+using System.Net;
 using System.Security.Cryptography;
 
 namespace Synapse.Core.Infrastructure.Services;
@@ -29,28 +31,33 @@ public class DatabaseInitializer(ILoggerFactory loggerFactory, IServiceProvider 
     /// <inheritdoc/>
     protected override async Task SeedAsync(CancellationToken cancellationToken)
     {
-        foreach (var definition in SynapseDefaults.Resources.Definitions.AsEnumerable()) await this.Database.CreateResourceAsync(definition, cancellationToken: cancellationToken).ConfigureAwait(false);
+        foreach (var definition in SynapseDefaults.Resources.Definitions.AsEnumerable())
+        {
+            try { await this.Database.CreateResourceAsync(definition, cancellationToken: cancellationToken).ConfigureAwait(false); }
+            catch (ProblemDetailsException ex) when (ex.Problem.Status == (int)HttpStatusCode.Conflict || (ex.Problem.Status == (int)HttpStatusCode.BadRequest && ex.Problem.Title == "Conflict")) { continue; }
+        }
         var keyBytes = new byte[64];
         using var rng = RandomNumberGenerator.Create();
         rng.GetBytes(keyBytes);
         var key = Convert.ToBase64String(keyBytes);
-        await this.Database.CreateResourceAsync(new ServiceAccount()
+        try
         {
-            Metadata = new()
+            await this.Database.CreateResourceAsync(new ServiceAccount()
             {
-                Namespace = Namespace.DefaultNamespaceName,
-                Name = ServiceAccount.DefaultServiceAccountName
-            },
-            Spec = new()
-            {
-                Key = key,
-                Claims = new Dictionary<string, string>()
+                Metadata = new()
                 {
-
+                    Namespace = Namespace.DefaultNamespaceName,
+                    Name = ServiceAccount.DefaultServiceAccountName
+                },
+                Spec = new()
+                {
+                    Key = key,
+                    Claims = new Dictionary<string, string>() { }
                 }
-            }
-        }, false, cancellationToken).ConfigureAwait(false);
-        await this.Database.InitializeAsync(cancellationToken);
+            }, false, cancellationToken).ConfigureAwait(false);
+            await this.Database.InitializeAsync(cancellationToken);
+        }
+        catch (ProblemDetailsException ex) when (ex.Problem.Status == (int)HttpStatusCode.Conflict || (ex.Problem.Status == (int)HttpStatusCode.BadRequest && ex.Problem.Title == "Conflict")) { continue; }
     }
 
 }

--- a/src/core/Synapse.Core.Infrastructure/Synapse.Core.Infrastructure.csproj
+++ b/src/core/Synapse.Core.Infrastructure/Synapse.Core.Infrastructure.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha2</VersionSuffix>
+	<VersionSuffix>alpha3</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/core/Synapse.Core/Synapse.Core.csproj
+++ b/src/core/Synapse.Core/Synapse.Core.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha2</VersionSuffix>
+	<VersionSuffix>alpha3</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/core/Synapse.Core/SynapseDefaults.cs
+++ b/src/core/Synapse.Core/SynapseDefaults.cs
@@ -54,6 +54,40 @@ public static class SynapseDefaults
         public const string TypePrefix = "io.synapse-wfms.events.";
 
         /// <summary>
+        /// Exposes constants about the Synapse cloud event bus
+        /// </summary>
+        public static class Bus
+        {
+
+            /// <summary>
+            /// Gets the name of the stream used to observe cloud events published to the Synapse cloud event bus
+            /// </summary>
+            public const string StreamName = "cloud-events";
+            /// <summary>
+            /// Gets the name of the field used to store the serialized cloud event
+            /// </summary>
+            public const string EventFieldName = "event";
+            /// <summary>
+            /// Gets the key of the list used to store all existing consumer groups
+            /// </summary>
+            public const string ConsumerGroupListKey = "cloud-events-consumer-groups";
+            /// <summary>
+            /// Gets the LUA script used to distribute cloud event bus messages amongst consumer groups
+            /// </summary>
+            public static string MessageDistributionScript = @"
+local message = redis.call('RPOP', KEYS[1]);
+if message then 
+    local consumerGroups = redis.call('SMEMBERS', KEYS[2]); 
+    for _, group in ipairs(consumerGroups) do 
+        redis.call('LPUSH', group, message); 
+    end; 
+end; 
+return message;
+";
+
+        }
+
+        /// <summary>
         /// Exposes constants about workflow-related cloud events
         /// </summary>
         public static class Workflow
@@ -496,6 +530,24 @@ public static class SynapseDefaults
             /// Gets the environment variable used to configure the correlator's name
             /// </summary>
             public const string Name = Prefix + "NAME";
+
+            /// <summary>
+            /// Exposes constants about the cloud events related environment variables of a correlator
+            /// </summary>
+            public static class Events
+            {
+
+                /// <summary>
+                /// Gets the prefix for all correlator related environment variables
+                /// </summary>
+                public const string Prefix = Correlator.Prefix + "EVENTS_";
+
+                /// <summary>
+                /// Gets the name of the consumer group the correlator to configure belongs to, if any
+                /// </summary>
+                public const string ConsumerGroup = Prefix + "CONSUMER";
+
+            }
 
         }
 

--- a/src/correlator/Synapse.Correlator/Configuration/CloudEventConsumptionOptions.cs
+++ b/src/correlator/Synapse.Correlator/Configuration/CloudEventConsumptionOptions.cs
@@ -1,0 +1,27 @@
+﻿// Copyright © 2024-Present The Synapse Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Synapse.Correlator.Configuration;
+
+/// <summary>
+/// Represents the options used to configure the way a Synapse Correlator consumes cloud events
+/// </summary>
+public class CloudEventConsumptionOptions
+{
+
+    /// <summary>
+    /// Gets/sets the name of the correlator's consumer group, if any. If not set, defaults to a concatenation of the correlators name and namespace.
+    /// </summary>
+    public virtual string? ConsumerGroup { get; set; }
+
+}

--- a/src/correlator/Synapse.Correlator/Configuration/CorrelatorOptions.cs
+++ b/src/correlator/Synapse.Correlator/Configuration/CorrelatorOptions.cs
@@ -24,8 +24,14 @@ public class CorrelatorOptions
     /// </summary>
     public CorrelatorOptions()
     {
-        Namespace = Environment.GetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.Correlator.Namespace)!;
-        Name = Environment.GetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.Correlator.Name)!;
+        this.Namespace = Environment.GetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.Correlator.Namespace)!;
+        this.Name = Environment.GetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.Correlator.Name)!;
+        var env = Environment.GetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.Correlator.Events.ConsumerGroup);
+        if (!string.IsNullOrWhiteSpace(env))
+        {
+            this.Events ??= new();
+            this.Events.ConsumerGroup = env;
+        }
     }
 
     /// <summary>
@@ -37,5 +43,10 @@ public class CorrelatorOptions
     /// Gets/sets the correlator's name
     /// </summary>
     public virtual string Name { get; set; }
+
+    /// <summary>
+    /// Gets/sets the options used to configure the way a Synapse Correlator consumes cloud events
+    /// </summary>
+    public virtual CloudEventConsumptionOptions? Events { get; set; }
 
 }

--- a/src/correlator/Synapse.Correlator/Program.cs
+++ b/src/correlator/Synapse.Correlator/Program.cs
@@ -31,6 +31,9 @@ builder.Services.AddJavaScriptExpressionEvaluator();
 builder.Services.AddCloudEventBus();
 builder.Services.AddTransient<IRequestHandler<IngestCloudEventCommand, IOperationResult>, IngestCloudEventCommandHandler>();
 
+builder.Services.AddSingleton<RedisCloudEventIngestor>();
+builder.Services.AddHostedService(provider => provider.GetRequiredService<RedisCloudEventIngestor>());
+
 builder.Services.AddScoped<CorrelatorController>();
 builder.Services.AddScoped<ICorrelatorController>(provider => provider.GetRequiredService<CorrelatorController>());
 

--- a/src/correlator/Synapse.Correlator/Services/RedisCloudEventIngestor.cs
+++ b/src/correlator/Synapse.Correlator/Services/RedisCloudEventIngestor.cs
@@ -1,0 +1,197 @@
+﻿// Copyright © 2024-Present The Synapse Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using StackExchange.Redis;
+
+namespace Synapse.Correlator.Services;
+
+/// <summary>
+/// Represents a service used to ingest <see cref="CloudEvent"/>s using Redis
+/// </summary>
+/// <param name="logger">The service used to perform logging</param>
+/// <param name="connectionMultiplexer">The service used to connect to a Redis API</param>
+/// <param name="cloudEventBus">The service used to stream input and output <see cref="CloudEvent"/>s</param>
+/// <param name="jsonSerializer">The service used to serialize/deserialize data to/from JSON</param>
+/// <param name="options">The service used to access the current <see cref="CorrelatorOptions"/></param>
+public class RedisCloudEventIngestor(ILogger<RedisCloudEventIngestor> logger, IConnectionMultiplexer connectionMultiplexer, ICloudEventBus cloudEventBus, IJsonSerializer jsonSerializer, IOptions<CorrelatorOptions> options)
+    : IHostedService
+{
+
+    /// <summary>
+    /// Gets the service used to perform logging
+    /// </summary>
+    protected ILogger Logger { get; } = logger;
+
+    /// <summary>
+    /// Gets the service used to connect to a Redis API
+    /// </summary>
+    protected IConnectionMultiplexer ConnectionMultiplexer { get; } = connectionMultiplexer;
+
+    /// <summary>
+    /// Gets the Redis database to use
+    /// </summary>
+    protected StackExchange.Redis.IDatabase Database { get; } = connectionMultiplexer.GetDatabase();
+
+    /// <summary>
+    /// Gets the service used to stream input and output <see cref="CloudEvent"/>s
+    /// </summary>
+    protected ICloudEventBus CloudEventBus { get; } = cloudEventBus;
+
+    /// <summary>
+    /// Gets the service used to serialize/deserialize data to/from JSON
+    /// </summary>
+    protected IJsonSerializer JsonSerializer { get; } = jsonSerializer;
+
+    /// <summary>
+    /// Gets the current <see cref="CorrelatorOptions"/>
+    /// </summary>
+    protected CorrelatorOptions Options { get; } = options.Value;
+
+    /// <summary>
+    /// Gets the <see cref="RedisCloudEventIngestor"/>'s <see cref="System.Threading.CancellationTokenSource"/>
+    /// </summary>
+    protected CancellationTokenSource CancellationTokenSource { get; } = new();
+
+    /// <summary>
+    /// Gets a boolean indicating whether or not the Redis version used by the cloud event ingestor supports streaming commands
+    /// </summary>
+    protected bool SupportsStreaming { get; private set; }
+
+    /// <summary>
+    /// Gets the name of the cloud event consumer group the correlator belongs to
+    /// </summary>
+    protected string ConsumerGroup => this.Options.Events?.ConsumerGroup ?? $"{this.Options.Name}.{this.Options.Namespace}";
+
+    /// <summary>
+    /// Gets the key of the queue of the correlator's cloud event consumer group
+    /// </summary>
+    protected string ConsumerGroupQueue => $"cloud-event-consumer-group:{this.ConsumerGroup}";
+
+    /// <summary>
+    /// Gets the name of the correlator's cloud event consumer
+    /// </summary>
+    protected string Consumer => $"{this.Options.Name}.{this.Options.Namespace}";
+
+    /// <summary>
+    /// Gets the name of the queue used to push messages being processed by the consumer
+    /// </summary>
+    protected string ConsumerProcessingQueue => $"{this.Consumer}@{this.ConsumerGroup}:processing";
+
+    /// <inheritdoc/>
+    public virtual async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var version = ((string)(await this.Database.ExecuteAsync("INFO", "server").ConfigureAwait(false))!).Split('\n').FirstOrDefault(line => line.StartsWith("redis_version:"))?[14..]?.Trim() ?? "undetermined";
+        try
+        {
+            if (!(await this.Database.KeyExistsAsync(SynapseDefaults.CloudEvents.Bus.StreamName).ConfigureAwait(false))
+                || (await this.Database.StreamGroupInfoAsync(SynapseDefaults.CloudEvents.Bus.StreamName).ConfigureAwait(false)).All(x => x.Name != this.ConsumerGroup))
+                await this.Database.StreamCreateConsumerGroupAsync(SynapseDefaults.CloudEvents.Bus.StreamName, this.ConsumerGroup, StreamPosition.NewMessages, true).ConfigureAwait(false);
+            this.SupportsStreaming = true;
+            this.Logger.LogInformation("Redis server version '{version}' supports streaming commands. Streaming feature is enabled", version);
+        }
+        catch (RedisServerException ex) when (ex.Message.StartsWith("ERR unknown command"))
+        {
+            if (!(await this.Database.KeyExistsAsync(SynapseDefaults.CloudEvents.Bus.StreamName).ConfigureAwait(false))
+                || !(await this.Database.SetContainsAsync(SynapseDefaults.CloudEvents.Bus.ConsumerGroupListKey, this.ConsumerGroupQueue).ConfigureAwait(false)))
+                await this.Database.SetAddAsync(SynapseDefaults.CloudEvents.Bus.ConsumerGroupListKey, this.ConsumerGroupQueue).ConfigureAwait(false);
+            this.SupportsStreaming = false;
+            this.Logger.LogInformation("Redis server version '{version}' does not support streaming commands. Streaming feature is emulated using lists", version);
+        }
+        _ = this.StreamCloudEventsAsync();
+    }
+
+    /// <summary>
+    /// Ingests <see cref="CloudEvent"/>s published on the dedicated Redis stream
+    /// </summary>
+    /// <returns>A new awaitable <see cref="Task"/></returns>
+    protected virtual async Task StreamCloudEventsAsync()
+    {
+        try
+        {
+            if (this.SupportsStreaming)
+            {
+                var pendingInfo = await this.Database.StreamPendingAsync(SynapseDefaults.CloudEvents.Bus.StreamName, this.ConsumerGroup).ConfigureAwait(false);
+                var consumerInfo = pendingInfo.Consumers.FirstOrDefault(c => c.Name == this.Consumer);
+                if (consumerInfo.PendingMessageCount > 0)
+                {
+                    var pendingMessages = await this.Database.StreamReadGroupAsync(SynapseDefaults.CloudEvents.Bus.StreamName, this.ConsumerGroup, this.Consumer, count: consumerInfo.PendingMessageCount).ConfigureAwait(false);
+                    if (pendingMessages != null && pendingMessages.Length > 0) foreach (var message in pendingMessages) await this.ExtractAndPublishCloudEventAsync(message).ConfigureAwait(false);
+                }
+                while (!this.CancellationTokenSource.IsCancellationRequested)
+                {
+                    var pendingMessages = await this.Database.StreamReadGroupAsync(SynapseDefaults.CloudEvents.Bus.StreamName, this.ConsumerGroup, this.Consumer, ">", 1).ConfigureAwait(false);
+                    if (pendingMessages != null && pendingMessages.Length > 0) await this.ExtractAndPublishCloudEventAsync(pendingMessages.First()).ConfigureAwait(false);
+                    await Task.Delay(50).ConfigureAwait(false);
+                }
+            }
+            else
+            {
+                var pendingMessages = await this.Database.ListRangeAsync(this.ConsumerProcessingQueue, 0, -1).ConfigureAwait(false);
+                if (pendingMessages != null && pendingMessages.Length > 0) foreach (var message in pendingMessages) await this.ExtractAndPublishCloudEventAsync(message).ConfigureAwait(false);
+                while (!this.CancellationTokenSource.IsCancellationRequested)
+                {
+                    var message = await this.Database.ListRightPopLeftPushAsync(this.ConsumerGroupQueue, this.ConsumerProcessingQueue).ConfigureAwait(false);
+                    if (!string.IsNullOrEmpty(message)) await this.ExtractAndPublishCloudEventAsync(message).ConfigureAwait(false);
+                    await Task.Delay(50).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            this.Logger.LogError("An error occurred while ingesting cloud events: {ex}", ex);
+        }
+    }
+
+    /// <summary>
+    /// Extracts a <see cref="CloudEvent"/> from the specified <see cref="StreamEntry"/> and publish it onto the correlator's <see cref="ICloudEventBus"/>
+    /// </summary>
+    /// <param name="message">The <see cref="StreamEntry"/> to extract the <see cref="CloudEvent"/> from</param>
+    /// <returns>A new awaitable <see cref="Task"/></returns>
+    protected virtual async Task ExtractAndPublishCloudEventAsync(StreamEntry message)
+    {
+        try
+        {
+            var json = (string)message[SynapseDefaults.CloudEvents.Bus.EventFieldName]!;
+            var e = this.JsonSerializer.Deserialize<CloudEvent>(json)!;
+            this.CloudEventBus.InputStream.OnNext(e);
+            await this.Database.StreamAcknowledgeAsync(SynapseDefaults.CloudEvents.Bus.StreamName, this.ConsumerGroup, message.Id).ConfigureAwait(false);
+        }
+        catch(Exception ex)
+        {
+            this.Logger.LogError("An error occurred while extracting the cloud event from the message with id '{messageId}': {ex}", message.Id, ex);
+        }
+    }
+
+    /// <summary>
+    /// Extracts a <see cref="CloudEvent"/> from the specified <see cref="StreamEntry"/> and publish it onto the correlator's <see cref="ICloudEventBus"/>
+    /// </summary>
+    /// <param name="message">The <see cref="RedisValue"/> to extract the <see cref="CloudEvent"/> from</param>
+    /// <returns>A new awaitable <see cref="Task"/></returns>
+    protected virtual async Task ExtractAndPublishCloudEventAsync(RedisValue message)
+    {
+        try
+        {
+            var e = this.JsonSerializer.Deserialize<CloudEvent>(message!)!;
+            this.CloudEventBus.InputStream.OnNext(e);
+            await this.Database.ListLeftPopAsync(this.ConsumerProcessingQueue).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            this.Logger.LogError("An error occurred while extracting the cloud event from the specified message: {ex}", ex);
+        }
+    }
+
+    /// <inheritdoc/>
+    public virtual Task StopAsync(CancellationToken cancellationToken) => this.CancellationTokenSource.CancelAsync();
+
+}

--- a/src/correlator/Synapse.Correlator/Synapse.Correlator.csproj
+++ b/src/correlator/Synapse.Correlator/Synapse.Correlator.csproj
@@ -8,7 +8,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha2</VersionSuffix>
+	<VersionSuffix>alpha3</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/operator/Synapse.Operator/Synapse.Operator.csproj
+++ b/src/operator/Synapse.Operator/Synapse.Operator.csproj
@@ -8,7 +8,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha2</VersionSuffix>
+	<VersionSuffix>alpha3</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/runner/Synapse.Runner/Synapse.Runner.csproj
+++ b/src/runner/Synapse.Runner/Synapse.Runner.csproj
@@ -8,7 +8,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha2</VersionSuffix>
+	<VersionSuffix>alpha3</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/runtime/Synapse.Runtime.Abstractions/Synapse.Runtime.Abstractions.csproj
+++ b/src/runtime/Synapse.Runtime.Abstractions/Synapse.Runtime.Abstractions.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha2</VersionSuffix>
+	<VersionSuffix>alpha3</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/runtime/Synapse.Runtime.Docker/Synapse.Runtime.Docker.csproj
+++ b/src/runtime/Synapse.Runtime.Docker/Synapse.Runtime.Docker.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha2</VersionSuffix>
+	<VersionSuffix>alpha3</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/runtime/Synapse.Runtime.Kubernetes/Synapse.Runtime.Kubernetes.csproj
+++ b/src/runtime/Synapse.Runtime.Kubernetes/Synapse.Runtime.Kubernetes.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha2</VersionSuffix>
+	<VersionSuffix>alpha3</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/runtime/Synapse.Runtime.Native/Synapse.Runtime.Native.csproj
+++ b/src/runtime/Synapse.Runtime.Native/Synapse.Runtime.Native.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha2</VersionSuffix>
+	<VersionSuffix>alpha3</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Implements an internal cloud event bus, allowing solution components to correlate internally emitted events

**Additional information (if needed):**

The bus leverages Redis for its implementation. Based on the version of the Redis server in use, the APIs and correlators will either utilize Redis Streams or emulate streaming functionality through Redis Lists.
