### PR TITLE
Fixed the `OAuth2TokenManager` to not validate access token issuer name

### DIFF
--- a/src/api/Synapse.Api.Application/Configuration/AuthenticationPolicyOptions.cs
+++ b/src/api/Synapse.Api.Application/Configuration/AuthenticationPolicyOptions.cs
@@ -45,6 +45,25 @@ public class AuthenticationPolicyOptions
             this.Jwt ??= new();
             this.Jwt.Audience = env;
         }
+        env = Environment.GetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.Api.Authentication.Jwt.SigningKey);
+        if (!string.IsNullOrWhiteSpace(env))
+        {
+            this.Jwt ??= new();
+            this.Jwt.SigningKey = env;
+        }
+        env = Environment.GetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.Api.Authentication.Jwt.Issuer);
+        if (!string.IsNullOrWhiteSpace(env))
+        {
+            this.Jwt ??= new();
+            this.Jwt.Issuer = env;
+        }
+        env = Environment.GetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.Api.Authentication.Jwt.ValidateIssuer);
+        if (!string.IsNullOrWhiteSpace(env))
+        {
+            if (!bool.TryParse(env, out var validateIssuer)) throw new Exception($"Failed to parse the specified value '{env}' into a boolean");
+            this.Jwt ??= new();
+            this.Jwt.ValidateIssuer = validateIssuer;
+        }
         env = Environment.GetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.Api.Authentication.Oidc.Authority);
         if (!string.IsNullOrWhiteSpace(env))
         {

--- a/src/api/Synapse.Api.Application/Configuration/JwtBearerAuthenticationOptions.cs
+++ b/src/api/Synapse.Api.Application/Configuration/JwtBearerAuthenticationOptions.cs
@@ -43,6 +43,11 @@ public class JwtBearerAuthenticationOptions
     public virtual string? Issuer { get; set; }
 
     /// <summary>
+    /// Gets/sets a boolean indicating whether or not to validate the issuer of JWT tokens
+    /// </summary>
+    public virtual bool ValidateIssuer { get; set; } = true;
+
+    /// <summary>
     /// Gets the configured issuer signing key
     /// </summary>
     /// <returns>A new <see cref="SecurityKey"/></returns>

--- a/src/api/Synapse.Api.Application/Synapse.Api.Application.csproj
+++ b/src/api/Synapse.Api.Application/Synapse.Api.Application.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha3.1</VersionSuffix>
+	<VersionSuffix>alpha3.2</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/api/Synapse.Api.Client.Core/Synapse.Api.Client.Core.csproj
+++ b/src/api/Synapse.Api.Client.Core/Synapse.Api.Client.Core.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha3.1</VersionSuffix>
+	<VersionSuffix>alpha3.2</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/api/Synapse.Api.Client.Http/Synapse.Api.Client.Http.csproj
+++ b/src/api/Synapse.Api.Client.Http/Synapse.Api.Client.Http.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha3.1</VersionSuffix>
+	<VersionSuffix>alpha3.2</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/api/Synapse.Api.Http/Synapse.Api.Http.csproj
+++ b/src/api/Synapse.Api.Http/Synapse.Api.Http.csproj
@@ -8,7 +8,7 @@
 	<OutputType>Library</OutputType>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha3.1</VersionSuffix>
+	<VersionSuffix>alpha3.2</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/api/Synapse.Api.Server/Program.cs
+++ b/src/api/Synapse.Api.Server/Program.cs
@@ -75,7 +75,7 @@ if (applicationOptions.Authentication.Jwt != null)
             ValidAudience = applicationOptions.Authentication.Jwt.Audience,
             ValidateAudience = !string.IsNullOrWhiteSpace(applicationOptions.Authentication.Jwt.Audience),
             ValidIssuer = applicationOptions.Authentication.Jwt.Issuer,
-            ValidateIssuer = !string.IsNullOrWhiteSpace(applicationOptions.Authentication.Jwt.Issuer),
+            ValidateIssuer = applicationOptions.Authentication.Jwt.ValidateIssuer,
             IssuerSigningKey = applicationOptions.Authentication.Jwt.GetSigningKey()
         };
     });

--- a/src/api/Synapse.Api.Server/Synapse.Api.Server.csproj
+++ b/src/api/Synapse.Api.Server/Synapse.Api.Server.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha3.1</VersionSuffix>
+	<VersionSuffix>alpha3.2</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/cli/Synapse.Cli/Synapse.Cli.csproj
+++ b/src/cli/Synapse.Cli/Synapse.Cli.csproj
@@ -8,7 +8,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha3.1</VersionSuffix>
+	<VersionSuffix>alpha3.2</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/core/Synapse.Core.Infrastructure.Containers.Docker/Synapse.Core.Infrastructure.Containers.Docker.csproj
+++ b/src/core/Synapse.Core.Infrastructure.Containers.Docker/Synapse.Core.Infrastructure.Containers.Docker.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha3.1</VersionSuffix>
+	<VersionSuffix>alpha3.2</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/core/Synapse.Core.Infrastructure.Containers.Kubernetes/Synapse.Core.Infrastructure.Containers.Kubernetes.csproj
+++ b/src/core/Synapse.Core.Infrastructure.Containers.Kubernetes/Synapse.Core.Infrastructure.Containers.Kubernetes.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha3.1</VersionSuffix>
+	<VersionSuffix>alpha3.2</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/core/Synapse.Core.Infrastructure/Synapse.Core.Infrastructure.csproj
+++ b/src/core/Synapse.Core.Infrastructure/Synapse.Core.Infrastructure.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha3.1</VersionSuffix>
+	<VersionSuffix>alpha3.2</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/core/Synapse.Core/Synapse.Core.csproj
+++ b/src/core/Synapse.Core/Synapse.Core.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha3.1</VersionSuffix>
+	<VersionSuffix>alpha3.2</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/core/Synapse.Core/SynapseDefaults.cs
+++ b/src/core/Synapse.Core/SynapseDefaults.cs
@@ -440,18 +440,30 @@ return message;
                 {
 
                     /// <summary>
-                    /// Gets the prefix for all JWT Bearer related environment variables
+                    /// Gets the prefix for all JWT related environment variables
                     /// </summary>
                     public const string Prefix = Authentication.Prefix + "JWT_";
 
                     /// <summary>
-                    /// Gets the name of the environment variables used to specify the JWT Bearer authority to use
+                    /// Gets the name of the environment variables used to specify the JWT authority to use
                     /// </summary>
                     public const string Authority = Prefix + "AUTHORITY";
                     /// <summary>
-                    /// Gets the name of the environment variables used to specify the JWT Bearer audience
+                    /// Gets the name of the environment variables used to specify the JWT audience
                     /// </summary>
                     public const string Audience = Prefix + "AUDIENCE";
+                    /// <summary>
+                    /// Gets the name of the environment variables used to configure the key used to verify the signature of JWT tokens
+                    /// </summary>
+                    public const string SigningKey = Prefix + "SIGNING_KEY";
+                    /// <summary>
+                    /// Gets the name of the environment variables used to configure the expected issuer of JWT tokens
+                    /// </summary>
+                    public const string Issuer = Prefix + "ISSUER";
+                    /// <summary>
+                    /// Gets the name of the environment variables used to configure whether or not to validate the issuer of JWT tokens
+                    /// </summary>
+                    public const string ValidateIssuer = Prefix + "VALIDATE_ISSUER";
 
                 }
 

--- a/src/correlator/Synapse.Correlator/Synapse.Correlator.csproj
+++ b/src/correlator/Synapse.Correlator/Synapse.Correlator.csproj
@@ -8,7 +8,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha3.1</VersionSuffix>
+	<VersionSuffix>alpha3.2</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/operator/Synapse.Operator/Synapse.Operator.csproj
+++ b/src/operator/Synapse.Operator/Synapse.Operator.csproj
@@ -8,7 +8,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha3.1</VersionSuffix>
+	<VersionSuffix>alpha3.2</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/runner/Synapse.Runner/Services/Interfaces/IOAuth2TokenManager.cs
+++ b/src/runner/Synapse.Runner/Services/Interfaces/IOAuth2TokenManager.cs
@@ -13,7 +13,7 @@
 
 using ServerlessWorkflow.Sdk.Models.Authentication;
 
-namespace Synapse.Core.Infrastructure.Services;
+namespace Synapse.Runner.Services;
 
 /// <summary>
 /// Defines the fundamentals of a service used to manage <see cref="OAuth2Token"/>s

--- a/src/runner/Synapse.Runner/Services/OAuth2TokenManager.cs
+++ b/src/runner/Synapse.Runner/Services/OAuth2TokenManager.cs
@@ -12,18 +12,15 @@
 // limitations under the License.
 
 using IdentityModel.Client;
-using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
-using Neuroglia.Serialization;
-using ServerlessWorkflow.Sdk;
 using ServerlessWorkflow.Sdk.Models.Authentication;
 using System.Collections.Concurrent;
 using System.Net.Mime;
 using System.Security.Claims;
 using System.Text;
 
-namespace Synapse.Core.Infrastructure.Services;
+namespace Synapse.Runner.Services;
 
 /// <summary>
 /// Represents the default implementation of the <see cref="IOAuth2TokenManager"/> interface
@@ -69,6 +66,7 @@ public class OAuth2TokenManager(ILogger<OAuth2TokenManager> logger, IJsonSeriali
                 Address = configuration.Authority!.OriginalString,
                 Policy = new()
                 {
+                    ValidateIssuerName = false,
                     RequireHttps = false
                 }
             };

--- a/src/runner/Synapse.Runner/Synapse.Runner.csproj
+++ b/src/runner/Synapse.Runner/Synapse.Runner.csproj
@@ -8,7 +8,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha3.1</VersionSuffix>
+	<VersionSuffix>alpha3.2</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/runtime/Synapse.Runtime.Abstractions/Synapse.Runtime.Abstractions.csproj
+++ b/src/runtime/Synapse.Runtime.Abstractions/Synapse.Runtime.Abstractions.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha3.1</VersionSuffix>
+	<VersionSuffix>alpha3.2</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/runtime/Synapse.Runtime.Docker/Synapse.Runtime.Docker.csproj
+++ b/src/runtime/Synapse.Runtime.Docker/Synapse.Runtime.Docker.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha3.1</VersionSuffix>
+	<VersionSuffix>alpha3.2</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/runtime/Synapse.Runtime.Kubernetes/Synapse.Runtime.Kubernetes.csproj
+++ b/src/runtime/Synapse.Runtime.Kubernetes/Synapse.Runtime.Kubernetes.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha3.1</VersionSuffix>
+	<VersionSuffix>alpha3.2</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/runtime/Synapse.Runtime.Native/Synapse.Runtime.Native.csproj
+++ b/src/runtime/Synapse.Runtime.Native/Synapse.Runtime.Native.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha3.1</VersionSuffix>
+	<VersionSuffix>alpha3.2</VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Moves the `IOAuth2TokenManager` and its implementation from the Infrastructure project to the runner's
- Fixes the `OAuth2TokenManager` to not validate access token issuer name
- Addes environment variable based configuration of the API's JwT issuer, its signing key and its name validation

Signed-off-by: Charles d'Avernas <charles.davernas@neuroglia.io>