### PR TITLE
fix(Runner): Fixed the OAuth2TokenManager to not validate the OIDC discovery document endpoints

### DIFF
--- a/src/runner/Synapse.Runner/Services/OAuth2TokenManager.cs
+++ b/src/runner/Synapse.Runner/Services/OAuth2TokenManager.cs
@@ -67,6 +67,7 @@ public class OAuth2TokenManager(ILogger<OAuth2TokenManager> logger, IJsonSeriali
                 Policy = new()
                 {
                     ValidateIssuerName = false,
+                    ValidateEndpoints = false,
                     RequireHttps = false
                 }
             };


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the OAuth2TokenManager to not validate the OIDC discovery document endpoints