### PR TITLE
Fixed the `WorkflowExecutionContext` to properly set the status of an ended task

### DIFF
--- a/src/runner/Synapse.Runner/Services/WorkflowExecutionContext.cs
+++ b/src/runner/Synapse.Runner/Services/WorkflowExecutionContext.cs
@@ -538,7 +538,7 @@ public class WorkflowExecutionContext(IServiceProvider services, IExpressionEval
                 {
                     Workflow = this.Instance.GetQualifiedName(),
                     Task = task.Reference,
-                    Status = this.Instance.Status!.Phase!,
+                    Status = task.Status!,
                     EndedAt = run?.EndedAt ?? DateTimeOffset.Now
                 }
             }, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the `WorkflowExecutionContext` to properly set the status of an ended task, which was being wrongly set to the workflow instance's status