### PR TITLE
Fixed the API client to use SSEs for watching and monitoring resources

### DIFF
--- a/src/api/Synapse.Api.Client.Core/Services/IClusterResourceApiClient.cs
+++ b/src/api/Synapse.Api.Client.Core/Services/IClusterResourceApiClient.cs
@@ -38,7 +38,7 @@ public interface IClusterResourceApiClient<TResource>
     /// <param name="labelSelectors">Defines the expected labels, if any, of the resources to watch</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
     /// <returns>A new <see cref="IAsyncEnumerable{T}"/> used to asynchronously enumerate resulting <see cref="IResourceWatchEvent"/>s</returns>
-    Task<IAsyncEnumerable<IResourceWatchEvent<TResource>>> WatchAsync(IEnumerable<LabelSelector>? labelSelectors = null, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<IResourceWatchEvent<TResource>> WatchAsync(IEnumerable<LabelSelector>? labelSelectors = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Monitors the resource with the specified name
@@ -46,7 +46,7 @@ public interface IClusterResourceApiClient<TResource>
     /// <param name="name">The name of the resource to monitor</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
     /// <returns>A new <see cref="IAsyncEnumerable{T}"/> used to asynchronously enumerate resulting <see cref="IResourceWatchEvent"/>s</returns>
-    Task<IAsyncEnumerable<IResourceWatchEvent<TResource>>> MonitorAsync(string name, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<IResourceWatchEvent<TResource>> MonitorAsync(string name, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the resource with the specified name

--- a/src/api/Synapse.Api.Client.Core/Services/INamespacedResourceApiClient.cs
+++ b/src/api/Synapse.Api.Client.Core/Services/INamespacedResourceApiClient.cs
@@ -40,7 +40,7 @@ public interface INamespacedResourceApiClient<TResource>
     /// <param name="labelSelectors">Defines the expected labels, if any, of the resources to watch</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
     /// <returns>A new <see cref="IAsyncEnumerable{T}"/> used to asynchronously enumerate resulting <see cref="IResourceWatchEvent"/>s</returns>
-    Task<IAsyncEnumerable<IResourceWatchEvent<TResource>>> WatchAsync(string? @namespace = null, IEnumerable<LabelSelector>? labelSelectors = null, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<IResourceWatchEvent<TResource>> WatchAsync(string? @namespace = null, IEnumerable<LabelSelector>? labelSelectors = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Monitors the resource with the specified name
@@ -49,7 +49,7 @@ public interface INamespacedResourceApiClient<TResource>
     /// <param name="namespace">The namespace the resource to monitor belongs to</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
     /// <returns>A new <see cref="IAsyncEnumerable{T}"/> used to asynchronously enumerate resulting <see cref="IResourceWatchEvent"/>s</returns>
-    Task<IAsyncEnumerable<IResourceWatchEvent<TResource>>> MonitorAsync(string name, string @namespace, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<IResourceWatchEvent<TResource>> MonitorAsync(string name, string @namespace, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the resource with the specified name

--- a/src/api/Synapse.Api.Client.Http/Services/ResourceHttpApiClient.cs
+++ b/src/api/Synapse.Api.Client.Http/Services/ResourceHttpApiClient.cs
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Runtime.CompilerServices;
+
 namespace Synapse.Api.Client.Services;
 
 /// <summary>
@@ -105,25 +107,32 @@ public class ResourceHttpApiClient<TResource>(IServiceProvider serviceProvider, 
     }
 
     /// <inheritdoc/>
-    public virtual async Task<IAsyncEnumerable<IResourceWatchEvent<TResource>>> WatchAsync(string? @namespace = null, IEnumerable<LabelSelector>? labelSelectors = null, CancellationToken cancellationToken = default)
+    public virtual async IAsyncEnumerable<IResourceWatchEvent<TResource>> WatchAsync(string? @namespace = null, IEnumerable<LabelSelector>? labelSelectors = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var resource = new TResource();
-        var uri = string.IsNullOrWhiteSpace(@namespace) ? $"/api/{resource.Definition.Version}/{resource.Definition.Plural}/watch" : $"/api/{resource.Definition.Version}/{resource.Definition.Plural}/{@namespace}/watch";
+        var uri = string.IsNullOrWhiteSpace(@namespace) ? $"/api/{resource.Definition.Version}/{resource.Definition.Plural}/watch/sse" : $"/api/{resource.Definition.Version}/{resource.Definition.Plural}/{@namespace}/watch";
         var queryStringArguments = new Dictionary<string, string>();
         if (labelSelectors?.Any() == true) queryStringArguments.Add("labelSelector", labelSelectors.Select(s => s.ToString()).Join(','));
         if (queryStringArguments.Count != 0) uri += $"?{queryStringArguments.Select(kvp => $"{kvp.Key}={kvp.Value}").Join('&')}";
         using var request = await this.ProcessRequestAsync(new HttpRequestMessage(HttpMethod.Get, uri), cancellationToken).ConfigureAwait(false);
-        request.EnableWebAssemblyStreamingResponse();
         var response = await this.HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
         var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-        return this.JsonSerializer.DeserializeAsyncEnumerable<ResourceWatchEvent<TResource>>(responseStream, cancellationToken)!;
+        using var streamReader = new StreamReader(await response.Content.ReadAsStreamAsync());
+        while (!streamReader.EndOfStream)
+        {
+            var sseMessage = await streamReader.ReadLineAsync();
+            if (string.IsNullOrWhiteSpace(sseMessage)) continue;
+            var json = sseMessage["data: ".Length..].Trim();
+            var e = JsonSerializer.Deserialize<ResourceWatchEvent<TResource>>(json)!;
+            yield return e;
+        }
     }
 
     /// <inheritdoc/>
-    public virtual async Task<IAsyncEnumerable<IResourceWatchEvent<TResource>>> WatchAsync(IEnumerable<LabelSelector>? labelSelectors = null, CancellationToken cancellationToken = default)
+    public virtual async IAsyncEnumerable<IResourceWatchEvent<TResource>> WatchAsync(IEnumerable<LabelSelector>? labelSelectors = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var resource = new TResource();
-        var uri = $"/api/{resource.Definition.Version}/{resource.Definition.Plural}/watch";
+        var uri = $"/api/{resource.Definition.Version}/{resource.Definition.Plural}/watch/sse";
         var queryStringArguments = new Dictionary<string, string>();
         if (labelSelectors?.Any() == true) queryStringArguments.Add("labelSelector", labelSelectors.Select(s => s.ToString()).Join(','));
         if (queryStringArguments.Count != 0) uri += $"?{queryStringArguments.Select(kvp => $"{kvp.Key}={kvp.Value}").Join('&')}";
@@ -131,34 +140,56 @@ public class ResourceHttpApiClient<TResource>(IServiceProvider serviceProvider, 
         request.EnableWebAssemblyStreamingResponse();
         var response = await this.HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-        return this.JsonSerializer.DeserializeAsyncEnumerable<ResourceWatchEvent<TResource>>(responseStream, cancellationToken)!;
+        using var streamReader = new StreamReader(await response.Content.ReadAsStreamAsync());
+        while (!streamReader.EndOfStream)
+        {
+            var sseMessage = await streamReader.ReadLineAsync();
+            if (string.IsNullOrWhiteSpace(sseMessage)) continue;
+            var json = sseMessage["data: ".Length..].Trim();
+            var e = JsonSerializer.Deserialize<ResourceWatchEvent<TResource>>(json)!;
+            yield return e;
+        }
     }
 
     /// <inheritdoc/>
-    public virtual async Task<IAsyncEnumerable<IResourceWatchEvent<TResource>>> MonitorAsync(string name, string @namespace, CancellationToken cancellationToken = default)
+    public virtual async IAsyncEnumerable<IResourceWatchEvent<TResource>> MonitorAsync(string name, string @namespace, [EnumeratorCancellation]CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         ArgumentException.ThrowIfNullOrWhiteSpace(@namespace);
         var resource = new TResource();
-        var uri = $"/api/{resource.Definition.Version}/{resource.Definition.Plural}/{@namespace}/{name}/monitor";
+        var uri = $"/api/{resource.Definition.Version}/{resource.Definition.Plural}/{@namespace}/{name}/monitor/sse";
         using var request = await this.ProcessRequestAsync(new HttpRequestMessage(HttpMethod.Get, uri), cancellationToken).ConfigureAwait(false);
-        request.EnableWebAssemblyStreamingResponse();
         var response = await this.HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-        return this.JsonSerializer.DeserializeAsyncEnumerable<ResourceWatchEvent<TResource>>(responseStream, cancellationToken)!;
+        using var streamReader = new StreamReader(await response.Content.ReadAsStreamAsync());
+        while (!streamReader.EndOfStream)
+        {
+            var sseMessage = await streamReader.ReadLineAsync();
+            if (string.IsNullOrWhiteSpace(sseMessage)) continue;
+            var json = sseMessage["data: ".Length..].Trim();
+            var e = JsonSerializer.Deserialize<ResourceWatchEvent<TResource>>(json)!;
+            yield return e;
+        }
     }
 
     /// <inheritdoc/>
-    public virtual async Task<IAsyncEnumerable<IResourceWatchEvent<TResource>>> MonitorAsync(string name, CancellationToken cancellationToken = default)
+    public virtual async IAsyncEnumerable<IResourceWatchEvent<TResource>> MonitorAsync(string name, [EnumeratorCancellation]CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         var resource = new TResource();
-        var uri = $"/api/{resource.Definition.Version}/{resource.Definition.Plural}/{name}/monitor";
+        var uri = $"/api/{resource.Definition.Version}/{resource.Definition.Plural}/{name}/monitor/sse";
         using var request = await this.ProcessRequestAsync(new HttpRequestMessage(HttpMethod.Get, uri), cancellationToken).ConfigureAwait(false);
-        request.EnableWebAssemblyStreamingResponse();
         var response = await this.HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-        return this.JsonSerializer.DeserializeAsyncEnumerable<ResourceWatchEvent<TResource>>(responseStream, cancellationToken)!;
+        using var streamReader = new StreamReader(await response.Content.ReadAsStreamAsync());
+        while (!streamReader.EndOfStream)
+        {
+            var sseMessage = await streamReader.ReadLineAsync();
+            if (string.IsNullOrWhiteSpace(sseMessage)) continue;
+            var json = sseMessage["data: ".Length..].Trim();
+            var e = JsonSerializer.Deserialize<ResourceWatchEvent<TResource>>(json)!;
+            yield return e;
+        }
     }
 
     /// <inheritdoc/>

--- a/src/api/Synapse.Api.Http/ClusterResourceController.cs
+++ b/src/api/Synapse.Api.Http/ClusterResourceController.cs
@@ -108,6 +108,7 @@ public abstract class ClusterResourceController<TResource>(IMediator mediator, I
         this.Response.Headers.ContentType = "text/event-stream";
         this.Response.Headers.CacheControl = "no-cache";
         this.Response.Headers.Connection = "keep-alive";
+        await this.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
         await foreach (var e in response.Data!)
         {
             var sseMessage = $"data: {this.JsonSerializer.SerializeToText(e)}\\n\\n";
@@ -147,6 +148,7 @@ public abstract class ClusterResourceController<TResource>(IMediator mediator, I
         this.Response.Headers.ContentType = "text/event-stream";
         this.Response.Headers.CacheControl = "no-cache";
         this.Response.Headers.Connection = "keep-alive";
+        await this.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
         await foreach (var e in response.Data!)
         {
             var sseMessage = $"data: {this.JsonSerializer.SerializeToText(e)}\\n\\n";

--- a/src/api/Synapse.Api.Http/NamespacedResourceController.cs
+++ b/src/api/Synapse.Api.Http/NamespacedResourceController.cs
@@ -170,6 +170,7 @@ public abstract class NamespacedResourceController<TResource>(IMediator mediator
         this.Response.Headers.ContentType = "text/event-stream";
         this.Response.Headers.CacheControl = "no-cache";
         this.Response.Headers.Connection = "keep-alive";
+        await this.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
         await foreach (var e in response.Data!)
         {
             var sseMessage = $"data: {this.JsonSerializer.SerializeToText(e)}\\n\\n";
@@ -211,6 +212,7 @@ public abstract class NamespacedResourceController<TResource>(IMediator mediator
         this.Response.Headers.ContentType = "text/event-stream";
         this.Response.Headers.CacheControl = "no-cache";
         this.Response.Headers.Connection = "keep-alive";
+        await this.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
         await foreach(var e in response.Data!)
         {
             var sseMessage = $"data: {this.JsonSerializer.SerializeToText(e)}\\n\\n";

--- a/src/cli/Synapse.Cli/Commands/WorkflowInstances/MonitorWorkflowInstancesCommand.cs
+++ b/src/cli/Synapse.Cli/Commands/WorkflowInstances/MonitorWorkflowInstancesCommand.cs
@@ -64,8 +64,7 @@ internal class MonitorWorkflowInstancesCommand
     public async Task HandleAsync(string name, string @namespace, string output)
     {
         this.EnsureConfigured();
-        var enumerable = await this.Api.WorkflowInstances.MonitorAsync(name, @namespace);
-        await foreach (var e in enumerable)
+        await foreach (var e in this.Api.WorkflowInstances.MonitorAsync(name, @namespace))
         {
             string outputText = output.ToLowerInvariant() switch
             {

--- a/src/dashboard/Synapse.Dashboard/Components/ResourceEditor/ResourceEditor.razor
+++ b/src/dashboard/Synapse.Dashboard/Components/ResourceEditor/ResourceEditor.razor
@@ -258,7 +258,7 @@
             await this.JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", text);
             this.ToastService.Notify(new(ToastType.Success, "Copied to the clipboard!"));
         }
-        catch (Exception ex)
+        catch
         {
             this.ToastService.Notify(new(ToastType.Danger, "Failed to copy the definition to the clipboard."));
         }

--- a/src/runner/Synapse.Runner/Services/Executors/WorkflowProcessExecutor.cs
+++ b/src/runner/Synapse.Runner/Services/Executors/WorkflowProcessExecutor.cs
@@ -93,17 +93,16 @@ public class WorkflowProcessExecutor(IServiceProvider serviceProvider, ILogger<W
                 {
                     Definition = new()
                     {
-                        Namespace = this.ProcessDefinition.Namespace,
-                        Name = this.ProcessDefinition.Name,
-                        Version = this.ProcessDefinition.Version
+                        Namespace = workflowDefinition.Document.Namespace,
+                        Name = workflowDefinition.Document.Name,
+                        Version = workflowDefinition.Document.Version
                     },
                     Input = input
                 }
             };
             workflowInstance = await this.Api.WorkflowInstances.CreateAsync(workflowInstance, cancellationToken).ConfigureAwait(false);
         }
-        var watchEvents = await this.Api.WorkflowInstances.MonitorAsync(workflowInstance.GetName(), workflowInstance.GetNamespace()!, cancellationToken).ConfigureAwait(false);
-        await foreach(var watchEvent in watchEvents)
+        await foreach(var watchEvent in this.Api.WorkflowInstances.MonitorAsync(workflowInstance.GetName(), workflowInstance.GetNamespace()!, cancellationToken))
         {
             switch (watchEvent.Resource.Status?.Phase)
             {

--- a/src/runner/Synapse.Runner/Services/WorkflowExecutionContext.cs
+++ b/src/runner/Synapse.Runner/Services/WorkflowExecutionContext.cs
@@ -335,7 +335,7 @@ public class WorkflowExecutionContext(IServiceProvider services, IExpressionEval
         }
         var taskCompletionSource = new TaskCompletionSource<CorrelationContext>();
         using var cancellationTokenRegistration = cancellationToken.Register(() => taskCompletionSource.TrySetCanceled());
-        using var subscription = (await this.Api.WorkflowInstances.MonitorAsync(this.Instance.GetName(), this.Instance.GetNamespace()!, cancellationToken))
+        using var subscription = this.Api.WorkflowInstances.MonitorAsync(this.Instance.GetName(), this.Instance.GetNamespace()!, cancellationToken)
             .ToObservable()
             .Where(e => e.Type == ResourceWatchEventType.Updated)
             .Select(e => e.Resource.Status?.Correlation?.Contexts)


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the API client to use SSEs for watching and monitoring resources
- Fixes the actions to monitor and watch resources using SSEs in both cluster and namespaced resource controllers to flush headers directly

**Additional information**:

This fix is needed because the other, non SSE-based actions, block until the first event is consumed