### PR TITLE
Fixed the `WorkflowDefinitionEnumerableExtensions` by using the `SemVersio.PrecendenceComparer` when ordering versions of a workflow

### DIFF
--- a/src/core/Synapse.Core/Extensions/WorkflowDefinitionEnumerableExtensions.cs
+++ b/src/core/Synapse.Core/Extensions/WorkflowDefinitionEnumerableExtensions.cs
@@ -26,7 +26,7 @@ public static class WorkflowDefinitionEnumerableExtensions
     /// </summary>
     /// <param name="definitions">An <see cref="IEnumerable{T}"/> containing the <see cref="WorkflowDefinition"/>s to get the latest of</param>
     /// <returns>The latest <see cref="WorkflowDefinition"/></returns>
-    public static WorkflowDefinition GetLatest(this IEnumerable<WorkflowDefinition> definitions) => definitions.OrderByDescending(wf => SemVersion.Parse(wf.Document.Version, SemVersionStyles.Strict)).First();
+    public static WorkflowDefinition GetLatest(this IEnumerable<WorkflowDefinition> definitions) => definitions.OrderByDescending(wf => SemVersion.Parse(wf.Document.Version, SemVersionStyles.Strict), SemVersion.PrecedenceComparer).First();
 
     /// <summary>
     /// Gets the specified <see cref="WorkflowDefinition"/> version


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Fixed the `WorkflowDefinitionEnumerableExtensions` by using the `SemVersio.PrecendenceComparer` when ordering versions of a workflow