### PR TITLE
Fixed the `ForTaskExecutor`, which was not properly running when the list to enumerate contained only 1 item

### DIFF
--- a/src/runner/Synapse.Runner/Services/Executors/ForTaskExecutor.cs
+++ b/src/runner/Synapse.Runner/Services/Executors/ForTaskExecutor.cs
@@ -68,11 +68,15 @@ public class ForTaskExecutor(IServiceProvider serviceProvider, ILogger<ForTaskEx
     {
         if (this.Collection == null) throw new InvalidOperationException("The executor must be initialized before execution");
         var task = await this.Task.GetSubTasksAsync(cancellationToken).OrderBy(t => t.CreatedAt).LastOrDefaultAsync(cancellationToken).ConfigureAwait(false);
-        var index = task == null ? 0 : int.Parse(task.Reference.OriginalString.Split('/', StringSplitOptions.RemoveEmptyEntries).Last());
-        if (index == this.Collection.Count - 1)
+        var index = 0;
+        if (task != null)
         {
-            await this.SetResultAsync(this.Task.Input, this.Task.Definition.Then, cancellationToken).ConfigureAwait(false);
-            return;
+            index = int.Parse(task.Reference.OriginalString.Split('/', StringSplitOptions.RemoveEmptyEntries).Last());
+            if (index == this.Collection.Count - 1)
+            {
+                await this.SetResultAsync(this.Task.Input, this.Task.Definition.Then, cancellationToken).ConfigureAwait(false);
+                return;
+            }
         }
         var item = this.Collection.ElementAt(index);
         var taskDefinition = new DoTaskDefinition()


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the `ForTaskExecutor`, which was not properly running when the list to enumerate contained only 1 item