### PR TITLE
Improved workflow creation vs update process in the Dashboard

### DIFF
--- a/src/dashboard/Synapse.Dashboard/Pages/Functions/Create/State.cs
+++ b/src/dashboard/Synapse.Dashboard/Pages/Functions/Create/State.cs
@@ -18,7 +18,7 @@ using Synapse.Resources;
 namespace Synapse.Dashboard.Pages.Functions.Create;
 
 /// <summary>
-/// The <see cref="State{TState}"/> of the workflow editor
+/// The <see cref="State{TState}"/> of the function editor
 /// </summary>
 [Feature]
 public record CreateFunctionViewState
@@ -40,7 +40,12 @@ public record CreateFunctionViewState
     public SemVersion Version { get; set; } = new SemVersion(1, 0, 0);
 
     /// <summary>
-    /// Gets/sets the definition of the workflow to create
+    /// Gets/sets a boolean determining if the function is new or if it's an update
+    /// </summary>
+    public bool IsNew { get; set; } = true;
+
+    /// <summary>
+    /// Gets/sets the definition of the function to create
     /// </summary>
     public TaskDefinition? Function { get; set; } = null;
 

--- a/src/dashboard/Synapse.Dashboard/Pages/Functions/Create/View.razor
+++ b/src/dashboard/Synapse.Dashboard/Pages/Functions/Create/View.razor
@@ -47,10 +47,10 @@ else
         <PreferredLanguageSelector PreferredLanguageChange="Store.ToggleTextBasedEditorLanguageAsync" />
     </div>
     <StandaloneCodeEditor @ref="Store.TextEditor"
-                          ConstructionOptions="Store.StandaloneEditorConstructionOptions"
-                          OnDidInit="Store.OnTextBasedEditorInitAsync"
-                          OnDidChangeModelContent="Store.OnDidChangeModelContent"
-                          CssClass="h-100" />
+    ConstructionOptions="Store.StandaloneEditorConstructionOptions"
+    OnDidInit="Store.OnTextBasedEditorInitAsync"
+    OnDidChangeModelContent="Store.OnDidChangeModelContent"
+    CssClass="h-100" />
     @if (problemDetails != null)
     {
         <div class="problems px-3">
@@ -104,6 +104,7 @@ else
         await base.OnInitializedAsync();
         BreadcrumbManager.Use(Breadcrumbs.Functions);
         BreadcrumbManager.Add(new("New", "/functions/new"));
+        Store.SetIsNew(true);
         Store.Name.Subscribe(value => OnStateChanged(_ => name = value), token: CancellationTokenSource.Token);
         Store.ChosenName.Subscribe(value => OnStateChanged(_ => chosenName = value), token: CancellationTokenSource.Token);
         Store.Version.Subscribe(value => OnStateChanged(_ => version = value?.ToString()), token: CancellationTokenSource.Token);
@@ -115,7 +116,11 @@ else
     /// <inheritdoc/>
     protected override void OnParametersSet()
     {
-        if (Name != name) Store.SetName(Name);
+        if (Name != name)
+        {
+            Store.SetName(Name);
+            Store.SetIsNew(false);
+        }
     }
 
     protected void SetName()

--- a/src/dashboard/Synapse.Dashboard/Pages/Workflows/Create/State.cs
+++ b/src/dashboard/Synapse.Dashboard/Pages/Workflows/Create/State.cs
@@ -37,6 +37,11 @@ public record CreateWorkflowViewState
     public string? DslVersion { get; set; }
 
     /// <summary>
+    /// Gets/sets a boolean determining if the workflow is new or if it's an update
+    /// </summary>
+    public bool IsNew { get; set; } = true;
+
+    /// <summary>
     /// Gets/sets the definition of the workflow to create
     /// </summary>
     public WorkflowDefinition WorkflowDefinition { get; set; } = new WorkflowDefinition()

--- a/src/dashboard/Synapse.Dashboard/Pages/Workflows/Create/Store.cs
+++ b/src/dashboard/Synapse.Dashboard/Pages/Workflows/Create/Store.cs
@@ -19,7 +19,6 @@ using ServerlessWorkflow.Sdk.Validation;
 using Synapse.Api.Client.Services;
 using Synapse.Resources;
 using System.Text.RegularExpressions;
-using System.Xml.Linq;
 
 namespace Synapse.Dashboard.Pages.Workflows.Create;
 
@@ -513,6 +512,15 @@ public class CreateWorkflowViewStore(
         catch (Exception ex)
         {
             this.Logger.LogError("Unable to save workflow definition: {exception}", ex.ToString());
+            this.Reduce(state => state with
+            {
+                ProblemTitle = "Error",
+                ProblemDetail = "An error occurred while saving the workflow.",
+                ProblemErrors = new Dictionary<string, string[]>()
+                {
+                    {"Message", [ex.ToString()] }
+                }
+            });
         }
         finally
         {

--- a/src/dashboard/Synapse.Dashboard/Pages/Workflows/Create/View.razor
+++ b/src/dashboard/Synapse.Dashboard/Pages/Workflows/Create/View.razor
@@ -37,10 +37,10 @@ else
         <PreferredLanguageSelector PreferredLanguageChange="Store.ToggleTextBasedEditorLanguageAsync" />
     </div>
     <StandaloneCodeEditor @ref="Store.TextEditor"
-                          ConstructionOptions="Store.StandaloneEditorConstructionOptions"
-                          OnDidInit="Store.OnTextBasedEditorInitAsync"
-                          OnDidChangeModelContent="Store.OnDidChangeModelContent"
-                          CssClass="h-100" />
+    ConstructionOptions="Store.StandaloneEditorConstructionOptions"
+    OnDidInit="Store.OnTextBasedEditorInitAsync"
+    OnDidChangeModelContent="Store.OnDidChangeModelContent"
+    CssClass="h-100" />
     @if (problemDetails != null)
     {
         <div class="problems px-3">
@@ -93,6 +93,7 @@ else
         await base.OnInitializedAsync();
         BreadcrumbManager.Use(Breadcrumbs.Workflows);
         BreadcrumbManager.Add(new($"New", $"/workflows/new"));
+        Store.SetIsNew(true);
         Store.Namespace.Subscribe(value => OnStateChanged(_ => ns = value), token: CancellationTokenSource.Token);
         Store.Name.Subscribe(value => OnStateChanged(_ => name = value), token: CancellationTokenSource.Token);
         Store.Loading.Subscribe(value => OnStateChanged(_ => loading = value), token: CancellationTokenSource.Token);
@@ -110,6 +111,7 @@ else
         if (Name != name)
         {
             Store.SetName(Name);
+            Store.SetIsNew(false);
         }
     }
 


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
This PR introduces an improvement in the workflow creation/update page of the Synapse Dashboard by optimizing the API call behavior.

Previously, the application relied on calling the API to check if a workflow definition already existed, leading to a significant number of 404 errors in the logs when the definition was not found. This behavior was suboptimal and caused unnecessary strain on the API.

To address this, a variable in the page's state has been introduced to determine if the workflow needs to be created or updated. In addition, when creating, if a conflict is detected, the process will fallback and try to "update" (= create a new version).

Closes #457 