### PR TITLE
Fixed the ClusterResourceController by removing `namespace` path parameter from patch actions

### DIFF
--- a/src/api/Synapse.Api.Http/ClusterResourceController.cs
+++ b/src/api/Synapse.Api.Http/ClusterResourceController.cs
@@ -174,7 +174,7 @@ public abstract class ClusterResourceController<TResource>(IMediator mediator, I
     /// <param name="resourceVersion">The expected resource version, if any, used for optimistic concurrency</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
     /// <returns>A new <see cref="IActionResult"/></returns>
-    [HttpPatch("{namespace}/{name}")]
+    [HttpPatch("{name}")]
     [ProducesResponseType(typeof(Resource), (int)HttpStatusCode.OK)]
     [ProducesErrorResponseType(typeof(Neuroglia.ProblemDetails))]
     public virtual async Task<IActionResult> PatchResource(string name, [FromBody] Patch patch, string? resourceVersion = null, CancellationToken cancellationToken = default)
@@ -191,7 +191,7 @@ public abstract class ClusterResourceController<TResource>(IMediator mediator, I
     /// <param name="resourceVersion">The expected resource version, if any, used for optimistic concurrency</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
     /// <returns>A new <see cref="IActionResult"/></returns>
-    [HttpPatch("{namespace}/{name}/status")]
+    [HttpPatch("{name}/status")]
     [ProducesResponseType(typeof(Resource), (int)HttpStatusCode.OK)]
     [ProducesErrorResponseType(typeof(Neuroglia.ProblemDetails))]
     public virtual async Task<IActionResult> PatchResourceStatus(string name, [FromBody] Patch patch, string? resourceVersion = null, CancellationToken cancellationToken = default)

--- a/src/core/Synapse.Core/Extensions/TaskDefinitionVersionMapExtensions.cs
+++ b/src/core/Synapse.Core/Extensions/TaskDefinitionVersionMapExtensions.cs
@@ -26,14 +26,14 @@ public static class TaskDefinitionVersionMapExtensions
     /// </summary>
     /// <param name="definitions">An <see cref="IEnumerable{T}"/> containing the <see cref="TaskDefinition"/>s to get the latest of</param>
     /// <returns>The latest <see cref="TaskDefinition"/></returns>
-    public static TaskDefinition GetLatest(this Map<string, TaskDefinition> definitions) => definitions.OrderByDescending(kvp => SemVersion.Parse(kvp.Key, SemVersionStyles.Strict)).First().Value;
+    public static TaskDefinition GetLatest(this Map<string, TaskDefinition> definitions) => definitions.OrderByDescending(kvp => SemVersion.Parse(kvp.Key, SemVersionStyles.Strict), SemVersion.PrecedenceComparer).First().Value;
 
     /// <summary>
     /// Gets the latest version of the <see cref="TaskDefinition"/>
     /// </summary>
     /// <param name="definitions">An <see cref="IEnumerable{T}"/> containing the <see cref="TaskDefinition"/>s to get the latest of</param>
     /// <returns>The latest version</returns>
-    public static string GetLatestVersion(this Map<string, TaskDefinition> definitions) => definitions.OrderByDescending(kvp => SemVersion.Parse(kvp.Key, SemVersionStyles.Strict)).First().Key;
+    public static string GetLatestVersion(this Map<string, TaskDefinition> definitions) => definitions.OrderByDescending(kvp => SemVersion.Parse(kvp.Key, SemVersionStyles.Strict), SemVersion.PrecedenceComparer).First().Key;
 
     /// <summary>
     /// Gets the specified <see cref="TaskDefinition"/> version


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the ClusterResourceController by removing `namespace` path parameter from patch actions