### PR TITLE
Update the `HttpCallProcessor` and `OpenApiCallProcessor` to throw when a unexpected 3.x.x is returned by the remote server

### DIFF
--- a/src/runner/Synapse.Runner/Program.cs
+++ b/src/runner/Synapse.Runner/Program.cs
@@ -102,6 +102,10 @@ var builder = Host.CreateDefaultBuilder()
         services.AddPythonScriptExecutor();
         services.AddAsyncApi();
         services.AddAsyncApiClient(options => options.AddAllBindingHandlers());
+        services.AddHttpClient(RunnerDefaults.HttpClients.NoRedirect, _ => { }).ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler()
+        {
+            AllowAutoRedirect = false
+        });
         services.AddSingleton<SecretsManager>();
         services.AddSingleton<ISecretsManager>(provider => provider.GetRequiredService<SecretsManager>());
         services.AddSingleton<IHostedService>(provider => provider.GetRequiredService<SecretsManager>());

--- a/src/runner/Synapse.Runner/RunnerDefaults.cs
+++ b/src/runner/Synapse.Runner/RunnerDefaults.cs
@@ -20,6 +20,19 @@ public static class RunnerDefaults
 {
 
     /// <summary>
+    /// Exposes constants about <see cref="HttpClient"/>s
+    /// </summary>
+    public static class HttpClients
+    {
+
+        /// <summary>
+        /// Gets the name of the <see cref="HttpClient"/> configured to not automatically allow redirects
+        /// </summary>
+        public const string NoRedirect = "no-redirect";
+
+    }
+
+    /// <summary>
     /// Exposes constants about the Synapse Runner command line
     /// </summary>
     public static class CommandLine

--- a/src/runner/Synapse.Runner/Services/Executors/OpenApiCallExecutor.cs
+++ b/src/runner/Synapse.Runner/Services/Executors/OpenApiCallExecutor.cs
@@ -237,7 +237,7 @@ public class OpenApiCallExecutor(IServiceProvider serviceProvider, ILogger<OpenA
                     request.Content.Headers.ContentType.MediaType = content.MediaType;
                 }
             }
-            using var httpClient = this.HttpClientFactory.CreateClient();
+            using var httpClient = this.OpenApi.Redirect ? this.HttpClientFactory.CreateClient() : this.HttpClientFactory.CreateClient(RunnerDefaults.HttpClients.NoRedirect);
             await httpClient.ConfigureAuthenticationAsync(this.OpenApi.Authentication, this.ServiceProvider, this.Task.Workflow.Definition, cancellationToken).ConfigureAwait(false);
             using var response = await httpClient.SendAsync(request, cancellationToken);
             if (response.StatusCode == HttpStatusCode.ServiceUnavailable) continue;


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Update the `HttpCallProcessor` and `OpenApiCallProcessor` to throw when a unexpected 3.x.x is returned by the remote server