### PR TITLE
Fix the workflow schema validation, which was using obsolete URIs to get the schema files

### DIFF
--- a/src/dashboard/Synapse.Dashboard/Pages/Functions/Create/Store.cs
+++ b/src/dashboard/Synapse.Dashboard/Pages/Functions/Create/Store.cs
@@ -565,7 +565,7 @@ public class CreateFunctionViewStore(
         this._processingVersion = true;
         try
         {
-            var schema = $"https://raw.githubusercontent.com/serverlessworkflow/serverlessworkflow.github.io/main/static/schemas/{version}/workflow.yaml#/$defs/task";
+            var schema = $"https://raw.githubusercontent.com/serverlessworkflow/serverlessworkflow.github.io/main/public/schemas/{version}/workflow.yaml#/$defs/task";
             var type = $"create_{typeof(CustomFunction).Name.ToLower()}_{version}_schema";
             await this.MonacoInterop.AddValidationSchemaAsync(schema, $"https://synapse.io/schemas/{type}.json", $"{type}*").ConfigureAwait(false);
             this._textModelUri = this.MonacoEditorHelper.GetResourceUri(type);

--- a/src/dashboard/Synapse.Dashboard/Services/SpecificationSchemaManager.cs
+++ b/src/dashboard/Synapse.Dashboard/Services/SpecificationSchemaManager.cs
@@ -57,7 +57,7 @@ public class SpecificationSchemaManager(IYamlSerializer yamlSerializer, HttpClie
     public async Task<string> GetSchema(string version)
     {
         if (_knownSchemas.TryGetValue(version, out string? value)) return value;
-        var address = $"https://raw.githubusercontent.com/serverlessworkflow/serverlessworkflow.github.io/main/static/schemas/{version}/workflow.yaml";
+        var address = $"https://raw.githubusercontent.com/serverlessworkflow/serverlessworkflow.github.io/main/public/schemas/{version}/workflow.yaml";
         var yamlSchema = await this.HttpClient.GetStringAsync(address);
         this._knownSchemas.Add(version, this.YamlSerializer.ConvertToJson(yamlSchema));
         return this._knownSchemas[version];


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the workflow schema validation, which was using obsolete URIs to get the schema files