### PR TITLE
Fix the `WorkflowDefinitionExtensions` and `DoTaskDefinitionExtensions` to rely on name to determine the next task

### DIFF
--- a/src/runner/Synapse.Runner/Extensions/DoTaskDefinitionExtensions.cs
+++ b/src/runner/Synapse.Runner/Extensions/DoTaskDefinitionExtensions.cs
@@ -31,8 +31,7 @@ public static class DoTaskDefinitionExtensions
         switch (after.Next)
         {
             case FlowDirective.Continue:
-                var afterTask = doTask.Do[after.Name!];
-                var afterIndex = doTask.Do.Select(t => t.Value).ToList().IndexOf(afterTask);
+                var afterIndex = doTask.Do.Select(t => t.Key).ToList().IndexOf(after.Name!);
                 return doTask.Do.Skip(afterIndex + 1).FirstOrDefault();
             case FlowDirective.End: case FlowDirective.Exit: return default;
             default: return new(after.Next!, doTask.Do[after.Next!]);

--- a/src/runner/Synapse.Runner/Extensions/WorkflowDefinitionExtensions.cs
+++ b/src/runner/Synapse.Runner/Extensions/WorkflowDefinitionExtensions.cs
@@ -31,8 +31,7 @@ public static class WorkflowDefinitionExtensions
         switch (after.Status == TaskInstanceStatus.Skipped ? FlowDirective.Continue : after.Next)
         {
             case FlowDirective.Continue:
-                var afterTask = workflow.Do[after.Name!];
-                var afterIndex = workflow.Do.Select(e => e.Value).ToList().IndexOf(afterTask);
+                var afterIndex = workflow.Do.Select(kvp => kvp.Key).ToList().IndexOf(after.Name!);
                 return workflow.Do.Skip(afterIndex + 1).FirstOrDefault();
             case FlowDirective.End: case FlowDirective.Exit: return default;
             default: return new(after.Next!, workflow.Do[after.Next!]);

--- a/src/runner/Synapse.Runner/Services/ConnectedWorkflowExecutionContext.cs
+++ b/src/runner/Synapse.Runner/Services/ConnectedWorkflowExecutionContext.cs
@@ -123,7 +123,7 @@ public class ConnectedWorkflowExecutionContext(IServiceProvider services, ILogge
         }
         else
         {
-            var contextDocument = await this.Documents.CreateAsync($"{reference}/input", context, cancellationToken).ConfigureAwait(false);
+            var contextDocument = await this.Documents.CreateAsync($"{reference}/context", context, cancellationToken).ConfigureAwait(false);
             contextReference = contextDocument.Id;
         }
         var filteredInput = input;


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the `WorkflowDefinitionExtensions` and `DoTaskDefinitionExtensions` to rely on name to determine the next task, instead of relying of task record equality, which resulted in wrong resolution when the task had similar properties