### PR TITLE
Fix the `ListenTaskExecutor`, which did not work anymore without streaming

### DIFF
--- a/src/api/Synapse.Api.Application/Synapse.Api.Application.csproj
+++ b/src/api/Synapse.Api.Application/Synapse.Api.Application.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha5.12</VersionSuffix>
+	<VersionSuffix></VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/api/Synapse.Api.Client.Core/Synapse.Api.Client.Core.csproj
+++ b/src/api/Synapse.Api.Client.Core/Synapse.Api.Client.Core.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha5.12</VersionSuffix>
+	<VersionSuffix></VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/api/Synapse.Api.Client.Http/Synapse.Api.Client.Http.csproj
+++ b/src/api/Synapse.Api.Client.Http/Synapse.Api.Client.Http.csproj
@@ -43,7 +43,7 @@
 	
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.1" />
-	<PackageReference Include="ServerlessWorkflow.Sdk.IO" Version="1.0.0-alpha6.3" />
+	<PackageReference Include="ServerlessWorkflow.Sdk.IO" Version="1.0.0" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/api/Synapse.Api.Client.Http/Synapse.Api.Client.Http.csproj
+++ b/src/api/Synapse.Api.Client.Http/Synapse.Api.Client.Http.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha5.12</VersionSuffix>
+	<VersionSuffix></VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/api/Synapse.Api.Http/Synapse.Api.Http.csproj
+++ b/src/api/Synapse.Api.Http/Synapse.Api.Http.csproj
@@ -8,7 +8,7 @@
 	<OutputType>Library</OutputType>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha5.12</VersionSuffix>
+	<VersionSuffix></VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/api/Synapse.Api.Http/Synapse.Api.Http.csproj
+++ b/src/api/Synapse.Api.Http/Synapse.Api.Http.csproj
@@ -43,8 +43,8 @@
   </ItemGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Neuroglia.Mediation.AspNetCore" Version="4.18.1" />
-    <PackageReference Include="Neuroglia.Security.AspNetCore" Version="4.18.1" />
+    <PackageReference Include="Neuroglia.Mediation.AspNetCore" Version="4.19.0" />
+    <PackageReference Include="Neuroglia.Security.AspNetCore" Version="4.19.0" />
 	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />
   </ItemGroup>
 

--- a/src/api/Synapse.Api.Server/Synapse.Api.Server.csproj
+++ b/src/api/Synapse.Api.Server/Synapse.Api.Server.csproj
@@ -27,7 +27,6 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..\..</DockerfileContext>
 	<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-	<CETCompat>false</CETCompat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/api/Synapse.Api.Server/Synapse.Api.Server.csproj
+++ b/src/api/Synapse.Api.Server/Synapse.Api.Server.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha5.12</VersionSuffix>
+	<VersionSuffix></VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/cli/Synapse.Cli/Synapse.Cli.csproj
+++ b/src/cli/Synapse.Cli/Synapse.Cli.csproj
@@ -8,7 +8,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha5.12</VersionSuffix>
+	<VersionSuffix></VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/cli/Synapse.Cli/Synapse.Cli.csproj
+++ b/src/cli/Synapse.Cli/Synapse.Cli.csproj
@@ -33,7 +33,7 @@
 	<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
 	<PackageReference Include="moment.net" Version="1.3.4" />
 	<PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
-	<PackageReference Include="ServerlessWorkflow.Sdk.IO" Version="1.0.0-alpha6.3" />
+	<PackageReference Include="ServerlessWorkflow.Sdk.IO" Version="1.0.0" />
 	<PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>

--- a/src/core/Synapse.Core.Infrastructure.Containers.Docker/Synapse.Core.Infrastructure.Containers.Docker.csproj
+++ b/src/core/Synapse.Core.Infrastructure.Containers.Docker/Synapse.Core.Infrastructure.Containers.Docker.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha5.12</VersionSuffix>
+	<VersionSuffix></VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/core/Synapse.Core.Infrastructure.Containers.Kubernetes/Synapse.Core.Infrastructure.Containers.Kubernetes.csproj
+++ b/src/core/Synapse.Core.Infrastructure.Containers.Kubernetes/Synapse.Core.Infrastructure.Containers.Kubernetes.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha5.12</VersionSuffix>
+	<VersionSuffix></VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/core/Synapse.Core.Infrastructure/Synapse.Core.Infrastructure.csproj
+++ b/src/core/Synapse.Core.Infrastructure/Synapse.Core.Infrastructure.csproj
@@ -44,14 +44,14 @@
 	
   <ItemGroup>
 	<PackageReference Include="IdentityModel" Version="7.0.0" />
-	<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.3.0" />
-	<PackageReference Include="Neuroglia.Data.Expressions.Abstractions" Version="4.18.1" />
-	<PackageReference Include="Neuroglia.Data.Infrastructure.Redis" Version="4.18.1" />
-	<PackageReference Include="Neuroglia.Data.Infrastructure.ResourceOriented.Redis" Version="4.18.1" />
-	<PackageReference Include="Neuroglia.Mediation" Version="4.18.1" />
-	<PackageReference Include="Neuroglia.Plugins" Version="4.18.1" />
-	<PackageReference Include="Neuroglia.Serialization.Xml" Version="4.18.1" />
-	<PackageReference Include="ServerlessWorkflow.Sdk.IO" Version="1.0.0-alpha6.3" />
+	<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.3.1" />
+	<PackageReference Include="Neuroglia.Data.Expressions.Abstractions" Version="4.19.0" />
+	<PackageReference Include="Neuroglia.Data.Infrastructure.Redis" Version="4.19.0" />
+	<PackageReference Include="Neuroglia.Data.Infrastructure.ResourceOriented.Redis" Version="4.19.0" />
+	<PackageReference Include="Neuroglia.Mediation" Version="4.19.0" />
+	<PackageReference Include="Neuroglia.Plugins" Version="4.19.0" />
+	<PackageReference Include="Neuroglia.Serialization.Xml" Version="4.19.0" />
+	<PackageReference Include="ServerlessWorkflow.Sdk.IO" Version="1.0.0" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/src/core/Synapse.Core.Infrastructure/Synapse.Core.Infrastructure.csproj
+++ b/src/core/Synapse.Core.Infrastructure/Synapse.Core.Infrastructure.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha5.12</VersionSuffix>
+	<VersionSuffix></VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/core/Synapse.Core/Synapse.Core.csproj
+++ b/src/core/Synapse.Core/Synapse.Core.csproj
@@ -66,11 +66,11 @@
   <ItemGroup>
 	<PackageReference Include="Apache.Avro" Version="1.12.0" />
 	<PackageReference Include="Docker.DotNet" Version="3.125.15" />
-	<PackageReference Include="KubernetesClient" Version="16.0.1" />
-	<PackageReference Include="Neuroglia.Data.Infrastructure.ResourceOriented" Version="4.18.1" />
-	<PackageReference Include="Neuroglia.Eventing.CloudEvents" Version="4.18.1" />
+	<PackageReference Include="KubernetesClient" Version="16.0.2" />
+	<PackageReference Include="Neuroglia.Data.Infrastructure.ResourceOriented" Version="4.19.0" />
+	<PackageReference Include="Neuroglia.Eventing.CloudEvents" Version="4.19.0" />
     <PackageReference Include="Semver" Version="3.0.0" />
-    <PackageReference Include="ServerlessWorkflow.Sdk" Version="1.0.0-alpha6.3" />
+    <PackageReference Include="ServerlessWorkflow.Sdk" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/core/Synapse.Core/Synapse.Core.csproj
+++ b/src/core/Synapse.Core/Synapse.Core.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha5.12</VersionSuffix>
+	<VersionSuffix></VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/correlator/Synapse.Correlator/Synapse.Correlator.csproj
+++ b/src/correlator/Synapse.Correlator/Synapse.Correlator.csproj
@@ -8,7 +8,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha5.12</VersionSuffix>
+	<VersionSuffix></VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/correlator/Synapse.Correlator/Synapse.Correlator.csproj
+++ b/src/correlator/Synapse.Correlator/Synapse.Correlator.csproj
@@ -36,12 +36,12 @@
 	<PackageReference Include="Microsoft.Extensions.Configuration.KeyPerFile" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-	<PackageReference Include="Neuroglia.Data.Expressions.JavaScript" Version="4.18.1" />
-	<PackageReference Include="Neuroglia.Data.Expressions.JQ" Version="4.18.1" />
-    <PackageReference Include="Neuroglia.Eventing.CloudEvents.AspNetCore" Version="4.18.1" />
-	<PackageReference Include="Neuroglia.Mediation.AspNetCore" Version="4.18.1" />
-	<PackageReference Include="Neuroglia.Eventing.CloudEvents.Infrastructure" Version="4.18.1" />
-	<PackageReference Include="Neuroglia.Security.AspNetCore" Version="4.18.1" />
+	<PackageReference Include="Neuroglia.Data.Expressions.JavaScript" Version="4.19.0" />
+	<PackageReference Include="Neuroglia.Data.Expressions.JQ" Version="4.19.0" />
+    <PackageReference Include="Neuroglia.Eventing.CloudEvents.AspNetCore" Version="4.19.0" />
+	<PackageReference Include="Neuroglia.Mediation.AspNetCore" Version="4.19.0" />
+	<PackageReference Include="Neuroglia.Eventing.CloudEvents.Infrastructure" Version="4.19.0" />
+	<PackageReference Include="Neuroglia.Security.AspNetCore" Version="4.19.0" />
 	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />
 	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
   </ItemGroup>

--- a/src/dashboard/Synapse.Dashboard/Synapse.Dashboard.csproj
+++ b/src/dashboard/Synapse.Dashboard/Synapse.Dashboard.csproj
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Blazor.Bootstrap" Version="3.2.0" />
+	<PackageReference Include="Blazor.Bootstrap" Version="3.3.0" />
     <PackageReference Include="BlazorMonaco" Version="3.3.0" />
     <PackageReference Include="IdentityModel" Version="7.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.1" />
 	<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.1" PrivateAssets="all" />
     <PackageReference Include="moment.net" Version="1.3.4" />
-    <PackageReference Include="Neuroglia.Blazor.Dagre" Version="4.18.1" />
+    <PackageReference Include="Neuroglia.Blazor.Dagre" Version="4.19.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/operator/Synapse.Operator/Synapse.Operator.csproj
+++ b/src/operator/Synapse.Operator/Synapse.Operator.csproj
@@ -8,7 +8,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha5.12</VersionSuffix>
+	<VersionSuffix></VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/runner/Synapse.Runner/Services/ConnectedWorkflowExecutionContext.cs
+++ b/src/runner/Synapse.Runner/Services/ConnectedWorkflowExecutionContext.cs
@@ -424,7 +424,7 @@ public class ConnectedWorkflowExecutionContext(IServiceProvider services, ILogge
     {
         ArgumentNullException.ThrowIfNull(task);
         if (task.Definition is not ListenTaskDefinition listenTask) throw new ArgumentException("The specified task's definition must be a 'listen' task", nameof(task));
-        if (listenTask.Foreach == null) throw new ArgumentException($"Since the specified listen task uses streaming, the {nameof(StreamAsync)} method must be used instead");
+        if (listenTask.Foreach != null) throw new ArgumentException($"Since the specified listen task uses streaming, the {nameof(StreamAsync)} method must be used instead");
         if (this.Instance.Status?.Correlation?.Contexts?.TryGetValue(task.Instance.Reference.OriginalString, out var context) == true && context != null) return context;
         var @namespace = task.Workflow.Instance.GetNamespace()!;
         var name = $"{task.Workflow.Instance.GetName()}.{task.Instance.Id}";

--- a/src/runner/Synapse.Runner/Services/Executors/ListenTaskExecutor.cs
+++ b/src/runner/Synapse.Runner/Services/Executors/ListenTaskExecutor.cs
@@ -64,8 +64,8 @@ public class ListenTaskExecutor(IServiceProvider serviceProvider, ILogger<Listen
             var context = await this.Task.CorrelateAsync(cancellationToken).ConfigureAwait(false);
             var events = this.Task.Definition.Listen.Read switch
             {
-                EventReadMode.Data or EventReadMode.Raw => context.Events.Select(e => e.Value.Data),
-                EventReadMode.Envelope => context.Events.Select(e => e.Value.Data),
+                EventReadMode.Data or EventReadMode.Raw or null => context.Events.Select(e => e.Value.Data),
+                EventReadMode.Envelope => context.Events.Select(e => e.Value),
                 _ => throw new NotSupportedException($"The specified event read mode '{this.Task.Definition.Listen.Read}' is not supported")
             };
             await this.SetResultAsync(events, this.Task.Definition.Then, cancellationToken).ConfigureAwait(false);
@@ -115,7 +115,7 @@ public class ListenTaskExecutor(IServiceProvider serviceProvider, ILogger<Listen
             var arguments = this.GetExpressionEvaluationArguments();
             var eventData = this.Task.Definition.Listen.Read switch
             {
-                EventReadMode.Data or EventReadMode.Raw => e.Event.Data,
+                EventReadMode.Data or EventReadMode.Raw or null => e.Event.Data,
                 EventReadMode.Envelope => e.Event,
                 _ => throw new NotSupportedException($"The specified event read mode '{this.Task.Definition.Listen.Read}' is not supported")
             };

--- a/src/runner/Synapse.Runner/Synapse.Runner.csproj
+++ b/src/runner/Synapse.Runner/Synapse.Runner.csproj
@@ -8,7 +8,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha5.12</VersionSuffix>
+	<VersionSuffix></VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/runner/Synapse.Runner/Synapse.Runner.csproj
+++ b/src/runner/Synapse.Runner/Synapse.Runner.csproj
@@ -59,15 +59,15 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
 	<PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.23" />
 	<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-	<PackageReference Include="MimeKit" Version="4.9.0" />
+	<PackageReference Include="MimeKit" Version="4.10.0" />
 	<PackageReference Include="Moq" Version="4.20.72" />
 	<PackageReference Include="Neuroglia.AsyncApi.Client.Bindings.All" Version="3.0.1" />
 	<PackageReference Include="Neuroglia.AsyncApi.DependencyInjectionExtensions" Version="3.0.1" />
-	<PackageReference Include="Neuroglia.Data.Expressions.JavaScript" Version="4.18.1" />
-	<PackageReference Include="Neuroglia.Data.Expressions.JQ" Version="4.18.1" />
-	<PackageReference Include="Neuroglia.Eventing.CloudEvents.Infrastructure" Version="4.18.1" />
-	<PackageReference Include="Neuroglia.Scripting.NodeJS" Version="4.18.1" />
-	<PackageReference Include="Neuroglia.Scripting.Python" Version="4.18.1" />
+	<PackageReference Include="Neuroglia.Data.Expressions.JavaScript" Version="4.19.0" />
+	<PackageReference Include="Neuroglia.Data.Expressions.JQ" Version="4.19.0" />
+	<PackageReference Include="Neuroglia.Eventing.CloudEvents.Infrastructure" Version="4.19.0" />
+	<PackageReference Include="Neuroglia.Scripting.NodeJS" Version="4.19.0" />
+	<PackageReference Include="Neuroglia.Scripting.Python" Version="4.19.0" />
 	<PackageReference Include="NReco.Logging.File" Version="1.2.2" />
 	<PackageReference Include="protobuf-net.Grpc.ClientFactory" Version="1.2.2" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />

--- a/src/runtime/Synapse.Runtime.Abstractions/Synapse.Runtime.Abstractions.csproj
+++ b/src/runtime/Synapse.Runtime.Abstractions/Synapse.Runtime.Abstractions.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha5.12</VersionSuffix>
+	<VersionSuffix></VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/runtime/Synapse.Runtime.Docker/Synapse.Runtime.Docker.csproj
+++ b/src/runtime/Synapse.Runtime.Docker/Synapse.Runtime.Docker.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha5.12</VersionSuffix>
+	<VersionSuffix></VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/runtime/Synapse.Runtime.Kubernetes/Synapse.Runtime.Kubernetes.csproj
+++ b/src/runtime/Synapse.Runtime.Kubernetes/Synapse.Runtime.Kubernetes.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha5.12</VersionSuffix>
+	<VersionSuffix></VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/src/runtime/Synapse.Runtime.Native/Synapse.Runtime.Native.csproj
+++ b/src/runtime/Synapse.Runtime.Native/Synapse.Runtime.Native.csproj
@@ -7,7 +7,7 @@
 	<NeutralLanguage>en</NeutralLanguage>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<VersionPrefix>1.0.0</VersionPrefix>
-	<VersionSuffix>alpha5.12</VersionSuffix>
+	<VersionSuffix></VersionSuffix>
 	<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 	<FileVersion>$(VersionPrefix)</FileVersion>
 	<Authors>The Synapse Authors</Authors>

--- a/tests/Synapse.IntegrationTests/Synapse.IntegrationTests.csproj
+++ b/tests/Synapse.IntegrationTests/Synapse.IntegrationTests.csproj
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.3">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.0.0" />
+    <PackageReference Include="FluentAssertions" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-	<PackageReference Include="ServerlessWorkflow.Sdk.Builders" Version="1.0.0-alpha6.3" />
+	<PackageReference Include="ServerlessWorkflow.Sdk.Builders" Version="1.0.0" />
     <PackageReference Include="Testcontainers" Version="4.1.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">

--- a/tests/Synapse.UnitTests/Synapse.UnitTests.csproj
+++ b/tests/Synapse.UnitTests/Synapse.UnitTests.csproj
@@ -10,20 +10,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.3">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.0.0" />
+    <PackageReference Include="FluentAssertions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Neuroglia.Data.Expressions.JQ" Version="4.18.1" />
-    <PackageReference Include="Neuroglia.Data.Infrastructure.Memory" Version="4.18.1" />
-    <PackageReference Include="Neuroglia.Data.Infrastructure.ResourceOriented.Redis" Version="4.18.1" />
-    <PackageReference Include="ServerlessWorkflow.Sdk.Builders" Version="1.0.0-alpha6.3" />
-	<PackageReference Include="ServerlessWorkflow.Sdk.IO" Version="1.0.0-alpha6.3" />
+    <PackageReference Include="Neuroglia.Data.Expressions.JQ" Version="4.19.0" />
+    <PackageReference Include="Neuroglia.Data.Infrastructure.Memory" Version="4.19.0" />
+    <PackageReference Include="Neuroglia.Data.Infrastructure.ResourceOriented.Redis" Version="4.19.0" />
+    <PackageReference Include="ServerlessWorkflow.Sdk.Builders" Version="1.0.0" />
+	<PackageReference Include="ServerlessWorkflow.Sdk.IO" Version="1.0.0" />
 	<PackageReference Include="System.Net.Http" Version="4.3.4" />
 	<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 	<PackageReference Include="Testcontainers" Version="4.1.0" />


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixed the `ListenTaskExecutor`, which did not work anymore without streaming, due to an invalid condition check
- Fixed the `ListenTaskExecutor`, which failed to read the content of events when the `ListenTask`'s `Read` property was not set.
- Fixed the `ListenTaskExecutor`, which was reading the payload of CloudEvents, even when the `ListenTask`'s `Read` property was set to `envelope`
