### PR TITLE
Fixed the `WorkflowProcessExecutor`, which was attempting to create a subflow using the runner's namespace, instead of the configured one when creating a new subflow instance

### DIFF
--- a/src/runner/Synapse.Runner/Services/Executors/WorkflowProcessExecutor.cs
+++ b/src/runner/Synapse.Runner/Services/Executors/WorkflowProcessExecutor.cs
@@ -60,7 +60,7 @@ public class WorkflowProcessExecutor(IServiceProvider serviceProvider, ILogger<W
     {
         var hash = Convert.ToHexString(MD5.HashData(Encoding.UTF8.GetBytes($"{Environment.GetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.Runner.Name)}{this.Task.Instance.Reference}"))).ToLowerInvariant();
         var workflowInstanceName = $"{this.ProcessDefinition.Name}-{hash}";
-        var workflowInstanceNamespace = Environment.GetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.Runner.Namespace)!;
+        var workflowInstanceNamespace = this.ProcessDefinition.Namespace;
         try
         {
             this.Subflow = await this.Api.WorkflowInstances.GetAsync(workflowInstanceName, workflowInstanceNamespace, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the `WorkflowProcessExecutor`, which was attempting to create a subflow using the runner's namespace, instead of the configured one when creating a new subflow instance

Fixes #484 