### PR TITLE
Fixed the `FunctionCallExecutor` to support custom functions that do not specify an @ catalog, falling back to the default Serverless Workflow catalog

### DIFF
--- a/src/runner/Synapse.Runner/Services/Executors/HttpCallExecutor.cs
+++ b/src/runner/Synapse.Runner/Services/Executors/HttpCallExecutor.cs
@@ -104,7 +104,7 @@ public class HttpCallExecutor(IServiceProvider serviceProvider, ILogger<HttpCall
         {
             requestContent = this.Http.Body switch
             {
-                string stringContent => new StringContent(stringContent, Encoding.UTF8, mediaType),
+                string stringContent => stringContent.IsRuntimeExpression() ? null : new StringContent(stringContent, Encoding.UTF8, mediaType),
                 byte[] byteArrayContent => new StreamContent(new MemoryStream(byteArrayContent)),
                 _ => null
             };


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the `FunctionCallExecutor` to support custom functions that do not specify an @ catalog, falling back to the default Serverless Workflow catalog
- Fixes the `HttpCallExecutor` to properly evaluate string-based body
- Registers a method used to fetch unresolved JsonSchemas