### PR TITLE
Fixed the operator to ignore workflows and workflow instances marked with mismatching `synapse.io/operator` labels

### DIFF
--- a/src/operator/Synapse.Operator/Services/WorkflowController.cs
+++ b/src/operator/Synapse.Operator/Services/WorkflowController.cs
@@ -95,7 +95,7 @@ public class WorkflowController(IServiceProvider serviceProvider, ILoggerFactory
     {
         ArgumentNullException.ThrowIfNull(workflow);
         if (this.Operator == null) throw new Exception("The controller must be started before attempting any operation");
-        if (workflow.Metadata.Labels != null && workflow.Metadata.Labels.TryGetValue(SynapseDefaults.Resources.Labels.Operator, out var operatorQualifiedName) && operatorQualifiedName == this.Operator.Resource.GetQualifiedName()) return true;
+        if (workflow.Metadata.Labels != null && workflow.Metadata.Labels.TryGetValue(SynapseDefaults.Resources.Labels.Operator, out var operatorQualifiedName)) return operatorQualifiedName == this.Operator.Resource.GetQualifiedName();
         try
         {
             var originalResource = workflow.Clone();
@@ -120,7 +120,7 @@ public class WorkflowController(IServiceProvider serviceProvider, ILoggerFactory
     protected virtual async Task<bool> TryReleaseAsync(Workflow workflow, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(workflow);
-        if (workflow.Metadata.Labels != null && workflow.Metadata.Labels.TryGetValue(SynapseDefaults.Resources.Labels.Operator, out var operatorQualifiedName) && operatorQualifiedName == this.Operator.Resource.GetQualifiedName()) return true;
+        if (workflow.Metadata.Labels != null && workflow.Metadata.Labels.TryGetValue(SynapseDefaults.Resources.Labels.Operator, out var operatorQualifiedName)) return operatorQualifiedName == this.Operator.Resource.GetQualifiedName();
         try
         {
             var originalResource = workflow.Clone();

--- a/src/operator/Synapse.Operator/Services/WorkflowInstanceController.cs
+++ b/src/operator/Synapse.Operator/Services/WorkflowInstanceController.cs
@@ -87,7 +87,7 @@ public class WorkflowInstanceController(IServiceProvider serviceProvider, ILogge
     protected virtual async Task<bool> TryClaimAsync(WorkflowInstance resource, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(resource);
-        if (resource.Metadata.Labels != null && resource.Metadata.Labels.TryGetValue(SynapseDefaults.Resources.Labels.Operator, out var operatorQualifiedName) && operatorQualifiedName == this.Operator.Resource.GetQualifiedName()) return true;
+        if (resource.Metadata.Labels != null && resource.Metadata.Labels.TryGetValue(SynapseDefaults.Resources.Labels.Operator, out var operatorQualifiedName)) return operatorQualifiedName == this.Operator.Resource.GetQualifiedName();
         try
         {
             var originalResource = resource.Clone();
@@ -112,7 +112,7 @@ public class WorkflowInstanceController(IServiceProvider serviceProvider, ILogge
     protected virtual async Task<bool> TryReleaseAsync(WorkflowInstance resource, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(resource);
-        if (resource.Metadata.Labels != null && resource.Metadata.Labels.TryGetValue(SynapseDefaults.Resources.Labels.Operator, out var operatorQualifiedName) && operatorQualifiedName == this.Operator.Resource.GetQualifiedName()) return true;
+        if (resource.Metadata.Labels != null && resource.Metadata.Labels.TryGetValue(SynapseDefaults.Resources.Labels.Operator, out var operatorQualifiedName)) return operatorQualifiedName == this.Operator.Resource.GetQualifiedName();
         try
         {
             var originalResource = resource.Clone();


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the operator to ignore workflows and workflow instances marked with mismatching `synapse.io/operator` labels

Fixes #515