### PR TITLE
Fixed the `DockerRuntime` to apply the provided `HostConfig`, thereby supporting volume mount functionality

### DIFF
--- a/deployments/docker-compose/.env
+++ b/deployments/docker-compose/.env
@@ -1,1 +1,1 @@
-GARNET_URI=garnet:6379
+REDIS_URI=redis:6379

--- a/deployments/docker-compose/docker-compose.yml
+++ b/deployments/docker-compose/docker-compose.yml
@@ -1,14 +1,14 @@
 services:
 
-  garnet:
-    image: ghcr.io/microsoft/garnet
+  redis:
+    image: redis:8.0.0
     volumes:
-      - garnet_data:/data
+      - redis_data:/data
  
   api:
     image: ghcr.io/serverlessworkflow/synapse/api
     environment:
-      CONNECTIONSTRINGS__REDIS: ${GARNET_URI}
+      CONNECTIONSTRINGS__REDIS: ${REDIS_URI}
       SYNAPSE_DASHBOARD_SERVE: 'true'
       SYNAPSE_API_AUTH_TOKEN_FILE: /app/tokens.yaml
       SYNAPSE_API_JWT_AUTHORITY: http://api:8080
@@ -18,12 +18,12 @@ services:
     ports:
       - 8080:8080
     depends_on:
-      - garnet
+      - redis
 
   operator:
     image: ghcr.io/serverlessworkflow/synapse/operator
     environment:
-      CONNECTIONSTRINGS__REDIS: ${GARNET_URI}
+      CONNECTIONSTRINGS__REDIS: ${REDIS_URI}
       SYNAPSE_OPERATOR_NAMESPACE: default
       SYNAPSE_OPERATOR_NAME: operator-1
       SYNAPSE_RUNNER_API: http://api:8080
@@ -37,25 +37,23 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     user: root
     depends_on:
-      - garnet
+      - redis
 
   correlator:
     image: ghcr.io/serverlessworkflow/synapse/correlator
     environment:
-      CONNECTIONSTRINGS__REDIS: ${GARNET_URI}
+      CONNECTIONSTRINGS__REDIS: ${REDIS_URI}
       SYNAPSE_CORRELATOR_NAMESPACE: default
       SYNAPSE_CORRELATOR_NAME: correlator-1
     ports:
       - 8081:8080
     depends_on:
-      - garnet
+      - redis
 
 volumes:
-
-  garnet_data:
+  redis_data:
     driver: local
 
 networks:
-
   default:
     name: synapse

--- a/src/core/Synapse.Core.Infrastructure.Containers.Docker/DockerContainerPlatform.cs
+++ b/src/core/Synapse.Core.Infrastructure.Containers.Docker/DockerContainerPlatform.cs
@@ -100,7 +100,7 @@ public class DockerContainerPlatform(ILogger<DockerContainerPlatform> logger, IH
             HostConfig = new()
             {
                 PortBindings = definition.Ports?.ToDictionary(kvp => kvp.Value.ToString(), kvp => (IList<PortBinding>)[new PortBinding() { HostPort = kvp.Key.ToString() }]),
-                Binds = definition.Volumes?.Select(e => $"{e.Key}={e.Value}")?.ToList() ?? []
+                Binds = definition.Volumes?.Select(e => $"{e.Key}:{e.Value}")?.ToList() ?? []
             }
         };
         var response = await this.Docker.Containers.CreateContainerAsync(parameters, cancellationToken).ConfigureAwait(false);

--- a/src/core/Synapse.Core/Resources/DockerRuntimeConfiguration.cs
+++ b/src/core/Synapse.Core/Resources/DockerRuntimeConfiguration.cs
@@ -81,15 +81,21 @@ public record DockerRuntimeConfiguration
     public virtual Config ContainerTemplate { get; set; } = LoadContainerTemplate();
 
     /// <summary>
+    /// Gets/sets the configuration of the host to use when running runner containers
+    /// </summary>
+    [DataMember(Order = 5, Name = "hostConfig"), JsonPropertyOrder(5), JsonPropertyName("hostConfig"), YamlMember(Order = 5, Alias = "hostConfig")]
+    public virtual HostConfig? HostConfig { get; set; }
+
+    /// <summary>
     /// Gets/sets the path to the directory that contains the secrets to mount in runner containers on a per workflow configuration basis
     /// </summary>
-    [DataMember(Order = 5, Name = "secrets"), JsonPropertyOrder(5), JsonPropertyName("secrets"), YamlMember(Order = 5, Alias = "secrets")]
+    [DataMember(Order = 6, Name = "secrets"), JsonPropertyOrder(6), JsonPropertyName("secrets"), YamlMember(Order = 6, Alias = "secrets")]
     public virtual DockerRuntimeSecretsConfiguration Secrets { get; set; } = new();
 
     /// <summary>
     /// Gets/sets the name of the network, if any, to connect Runner containers to
     /// </summary>
-    [DataMember(Order = 6, Name = "network"), JsonPropertyOrder(6), JsonPropertyName("network"), YamlMember(Order = 6, Alias = "network")]
+    [DataMember(Order = 7, Name = "network"), JsonPropertyOrder(7), JsonPropertyName("network"), YamlMember(Order = 7, Alias = "network")]
     public virtual string Network { get; set; } = DefaultNetwork;
 
     /// <summary>

--- a/src/dashboard/Synapse.Dashboard/Layout/MainLayout.razor
+++ b/src/dashboard/Synapse.Dashboard/Layout/MainLayout.razor
@@ -133,7 +133,7 @@
     {
         user = (await AuthenticationStateProvider.GetAuthenticationStateAsync()).User;
         AuthenticationStateProvider.AuthenticationStateChanged += OnAuthenticationStateChanged;
-        theme = await Storage.GetItemAsync("preferedTheme") ?? "dark";
+        theme = await Storage.GetItemAsync("preferredTheme") ?? "dark";
         await MonacoEditorHelper.ChangePreferredThemeAsync(theme);
         await base.OnInitializedAsync();
     }

--- a/src/dashboard/Synapse.Dashboard/Services/JsInterop.cs
+++ b/src/dashboard/Synapse.Dashboard/Services/JsInterop.cs
@@ -61,7 +61,7 @@ public class JSInterop(IJSRuntime jsRuntime, ILocalStorage storage, IMonacoEdito
     {
         var module = await moduleTask.Value;
         await module.InvokeVoidAsync("setTheme", theme);
-        await storage.SetItemAsync("preferedTheme", theme);
+        await storage.SetItemAsync("preferredTheme", theme);
         await monacoEditorHelper.ChangePreferredThemeAsync(theme);
     }
 

--- a/src/dashboard/Synapse.Dashboard/wwwroot/index.html
+++ b/src/dashboard/Synapse.Dashboard/wwwroot/index.html
@@ -43,8 +43,8 @@ limitations under the License.
     <link href="Synapse.Dashboard.styles.css" rel="stylesheet" />
     <link href="css/app.css" rel="stylesheet" />
     <script type="text/javascript">
-        const preferedTheme = localStorage.getItem('preferedTheme') || 'dark';
-        if (preferedTheme == 'light') {
+        const preferredTheme = localStorage.getItem('preferredTheme') || 'dark';
+        if (preferredTheme == 'light') {
             document.documentElement.removeAttribute('data-bs-theme');
         }
     </script>

--- a/src/runtime/Synapse.Runtime.Docker/Services/DockerRuntime.cs
+++ b/src/runtime/Synapse.Runtime.Docker/Services/DockerRuntime.cs
@@ -104,18 +104,16 @@ public class DockerRuntime(IServiceProvider serviceProvider, ILoggerFactory logg
             container.SetEnvironmentVariable("DOCKER_HOST", "unix:///var/run/docker.sock");
             container.User = "root";
             if (this.Runner.Certificates?.Validate == false) container.SetEnvironmentVariable(SynapseDefaults.EnvironmentVariables.SkipCertificateValidation, "true");
-            var hostConfig = new HostConfig()
-            {
-                Mounts = []
-            };
+            var hostConfig = this.Runner.Runtime.Docker.HostConfig?.Clone()! ?? new();
             if (!Directory.Exists(this.Runner.Runtime.Docker.Secrets.Directory)) Directory.CreateDirectory(this.Runner.Runtime.Docker.Secrets.Directory);
-            hostConfig.Mounts.Add(new()
+            hostConfig.Mounts ??= [];
+            hostConfig.Mounts.Insert(0, new()
             {
                 Type = "bind",
                 Source = this.Runner.Runtime.Docker.Secrets.Directory,
                 Target = this.Runner.Runtime.Docker.Secrets.MountPath
             });
-            hostConfig.Mounts.Add(new()
+            hostConfig.Mounts.Insert(1, new()
             {
                 Type = "bind",
                 Source = "/var/run/docker.sock",


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the `DockerRuntime` to apply the provided `HostConfig`, thereby supporting volume mount functionality
- Fixes the `DockerContainerPlatform` to properly initialize containers binds, thereby supporting volume mount functionality
- Fixes the docker-compose deployment by replacing `Garnet` by `Redis`

Fixes #521