### PR TITLE
Fixed the `WorkflowInstanceController` not to claim instances of workflows explicitly assigned to other operators

### DIFF
--- a/src/operator/Synapse.Operator/Program.cs
+++ b/src/operator/Synapse.Operator/Program.cs
@@ -62,6 +62,7 @@ var builder = Host.CreateDefaultBuilder()
 
         services.AddScoped<WorkflowController>();
         services.AddScoped<IResourceController<Workflow>>(provider => provider.GetRequiredService<WorkflowController>());
+        services.AddScoped<IWorkflowController>(provider => provider.GetRequiredService<WorkflowController>());
 
         services.AddScoped<WorkflowInstanceController>();
         services.AddScoped<IResourceController<WorkflowInstance>>(provider => provider.GetRequiredService<WorkflowInstanceController>());

--- a/src/operator/Synapse.Operator/Services/Interfaces/IWorkflowController.cs
+++ b/src/operator/Synapse.Operator/Services/Interfaces/IWorkflowController.cs
@@ -14,15 +14,14 @@
 namespace Synapse.Operator.Services;
 
 /// <summary>
-/// Defines the fundamentals of a service used to access the current Synapse Operator
+/// Defines the fundamentals of a service used to access all monitored workflows
 /// </summary>
-public interface IOperatorController
-    : IHostedService
+public interface IWorkflowController
 {
 
     /// <summary>
-    /// Gets the service used to monitor the current <see cref="Resources.Operator"/>
+    /// Gets a dictionary containing all monitored workflows
     /// </summary>
-    IResourceMonitor<Resources.Operator> Operator { get; }
+    IReadOnlyDictionary<string, Workflow> Workflows { get; }
 
 }

--- a/src/operator/Synapse.Operator/Services/WorkflowController.cs
+++ b/src/operator/Synapse.Operator/Services/WorkflowController.cs
@@ -25,7 +25,7 @@ namespace Synapse.Operator.Services;
 /// <param name="operatorOptions">The current <see cref="Configuration.OperatorOptions"/></param>
 /// <param name="operatorAccessor">The service used to access the current <see cref="Resources.Operator"/></param>
 public class WorkflowController(IServiceProvider serviceProvider, ILoggerFactory loggerFactory, IOptions<ResourceControllerOptions<Workflow>> controllerOptions, IResourceRepository resources, IOptions<OperatorOptions> operatorOptions, IOperatorController operatorAccessor)
-    : ResourceController<Workflow>(loggerFactory, controllerOptions, resources)
+    : ResourceController<Workflow>(loggerFactory, controllerOptions, resources), IWorkflowController
 {
 
     /// <summary>
@@ -47,6 +47,9 @@ public class WorkflowController(IServiceProvider serviceProvider, ILoggerFactory
     /// Gets a <see cref="ConcurrentDictionary{TKey, TValue}"/> that contains current <see cref="WorkflowScheduler"/>s
     /// </summary>
     protected ConcurrentDictionary<string, WorkflowScheduler> Schedulers { get; } = [];
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<string, Workflow> Workflows => this.Resources.AsReadOnly();
 
     /// <inheritdoc/>
     public override async Task StartAsync(CancellationToken cancellationToken)

--- a/src/operator/Synapse.Operator/Services/WorkflowInstanceController.cs
+++ b/src/operator/Synapse.Operator/Services/WorkflowInstanceController.cs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Neuroglia.Data.Infrastructure.ResourceOriented;
 using Neuroglia.Data.Infrastructure.Services;
 
 namespace Synapse.Operator.Services;
@@ -93,9 +94,8 @@ public class WorkflowInstanceController(IServiceProvider serviceProvider, ILogge
     protected virtual async Task<bool> TryClaimAsync(WorkflowInstance resource, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(resource);
-        if (resource.Metadata.Labels != null && resource.Metadata.Labels.TryGetValue(SynapseDefaults.Resources.Labels.Operator, out var operatorQualifiedName)) return operatorQualifiedName == this.Operator.Resource.GetQualifiedName();
-        if (this.Workflows.TryGetValue(this.GetResourceCacheKey(resource.Spec.Definition.Name, resource.Spec.Definition.Namespace), out var workflow) && workflow != null 
-            && workflow.Metadata.Labels != null && workflow.Metadata.Labels.TryGetValue(SynapseDefaults.Resources.Labels.Operator, out operatorQualifiedName)) return operatorQualifiedName == this.Operator.Resource.GetQualifiedName();
+        var isClaimable = this.IsWorkflowInstanceClaimable(resource);
+        if (isClaimable.HasValue) return isClaimable.Value;
         try
         {
             var originalResource = resource.Clone();
@@ -120,9 +120,8 @@ public class WorkflowInstanceController(IServiceProvider serviceProvider, ILogge
     protected virtual async Task<bool> TryReleaseAsync(WorkflowInstance resource, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(resource);
-        if (resource.Metadata.Labels != null && resource.Metadata.Labels.TryGetValue(SynapseDefaults.Resources.Labels.Operator, out var operatorQualifiedName)) return operatorQualifiedName == this.Operator.Resource.GetQualifiedName();
-        if (this.Workflows.TryGetValue(this.GetResourceCacheKey(resource.Spec.Definition.Name, resource.Spec.Definition.Namespace), out var workflow) && workflow != null
-           && workflow.Metadata.Labels != null && workflow.Metadata.Labels.TryGetValue(SynapseDefaults.Resources.Labels.Operator, out operatorQualifiedName)) return operatorQualifiedName == this.Operator.Resource.GetQualifiedName();
+        var isClaimable = this.IsWorkflowInstanceClaimable(resource);
+        if (isClaimable.HasValue) return isClaimable.Value;
         try
         {
             var originalResource = resource.Clone();
@@ -214,6 +213,20 @@ public class WorkflowInstanceController(IServiceProvider serviceProvider, ILogge
     /// <param name="selector">A key/value mapping of the labels both workflows and workflow instances to select must define</param>
     /// <returns>A new awaitable <see cref="Task"/></returns>
     protected virtual Task OnResourceSelectorChangedAsync(IDictionary<string, string>? selector) => this.ReconcileAsync(this.CancellationTokenSource.Token);
+
+    /// <summary>
+    /// Determines whether or not the specified <see cref="WorkflowInstance"/> can be claimed by the current <see cref="Resources.Operator"/>
+    /// </summary>
+    /// <param name="workflowInstance">The <see cref="WorkflowInstance"/> to check</param>
+    /// <returns>A boolean indicating whether or not the specified <see cref="WorkflowInstance"/> can be claimed by the current <see cref="Resources.Operator"/></returns>
+    protected virtual bool? IsWorkflowInstanceClaimable(WorkflowInstance workflowInstance)
+    {
+        ArgumentNullException.ThrowIfNull(workflowInstance);
+        if (workflowInstance.Metadata.Labels != null && workflowInstance.Metadata.Labels.TryGetValue(SynapseDefaults.Resources.Labels.Operator, out var operatorQualifiedName)) return operatorQualifiedName == this.Operator.Resource.GetQualifiedName();
+        if (this.Workflows.TryGetValue(this.GetResourceCacheKey(workflowInstance.Spec.Definition.Name, workflowInstance.Spec.Definition.Namespace), out var workflow) && workflow != null
+            && workflow.Metadata.Labels != null && workflow.Metadata.Labels.TryGetValue(SynapseDefaults.Resources.Labels.Operator, out operatorQualifiedName)) return operatorQualifiedName == this.Operator.Resource.GetQualifiedName();
+        return null;
+    }
 
     /// <inheritdoc/>
     protected override async ValueTask DisposeAsync(bool disposing)


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the `WorkflowInstanceController` not to claim instances of workflows explicitly assigned to other operators

Fixes #525