### PR TITLE
Preserve endpoint field by converting JSON to YAML in create/edit view of the Dashboard

### DIFF
--- a/src/dashboard/Synapse.Dashboard/Pages/Workflows/Create/Store.cs
+++ b/src/dashboard/Synapse.Dashboard/Pages/Workflows/Create/Store.cs
@@ -698,9 +698,8 @@ public class CreateWorkflowViewStore(
             string document = "";
             if (definition != null)
             {
-                document = MonacoEditorHelper.PreferredLanguage == PreferredLanguage.JSON ?
-                    JsonSerializer.SerializeToText(definition) :
-                    YamlSerializer.SerializeToText(definition);
+                document = JsonSerializer.SerializeToText(definition);
+                if (MonacoEditorHelper.PreferredLanguage == PreferredLanguage.YAML) document = YamlSerializer.ConvertFromJson(document);
             }
             Reduce(state => state with
             {


### PR DESCRIPTION


**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
The create/edit workflow view was serializing the definition directly to YAML, which caused endpoint fields to be replaced with `{}` in the editor.  

This PR aligns the behavior with the details view by always serializing to JSON first and converting to YAML only if the editor is configured for it.  

This ensures endpoint fields are correctly preserved when editing workflows in the UI.  

Closes #534

**Special notes for reviewers**:

**Additional information (if needed):**