### PR TITLE
Fixed the `WorkflowInstanceHandler` n,ot to use otpimistic concurrency when updating workflow instance status

### DIFF
--- a/src/operator/Synapse.Operator/Services/WorkflowInstanceHandler.cs
+++ b/src/operator/Synapse.Operator/Services/WorkflowInstanceHandler.cs
@@ -229,7 +229,7 @@ public class WorkflowInstanceHandler(ILogger<WorkflowInstanceHandler> logger, IO
                 updated.Status ??= new();
                 statusUpdate(updated.Status);
                 var patch = JsonPatchUtility.CreateJsonPatchFromDiff(original, updated);
-                await this.Resources.PatchStatusAsync<WorkflowInstance>(new Patch(PatchType.JsonPatch, patch), updated.GetName(), updated.GetNamespace(), original.Metadata.ResourceVersion, false, cancellationToken).ConfigureAwait(false);
+                await this.Resources.PatchStatusAsync<WorkflowInstance>(new Patch(PatchType.JsonPatch, patch), updated.GetName(), updated.GetNamespace(), null, false, cancellationToken).ConfigureAwait(false);
             }
             catch (ConcurrencyException) when (attempt + 1 < maxRetries)
             {


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the `WorkflowInstanceHandler` n,ot to use otpimistic concurrency when updating workflow instance status

Fixes #546 