### PR TITLE
Fixed the `WorkflowInstanceHandler` to ignore 304 errors when updating workflow instance status

### DIFF
--- a/src/core/Synapse.Core/Resources/RuntimeDefinition.cs
+++ b/src/core/Synapse.Core/Resources/RuntimeDefinition.cs
@@ -42,6 +42,6 @@ public record RuntimeDefinition
     /// Gets the runtime mode
     /// </summary>
     [IgnoreDataMember, JsonIgnore, YamlIgnore]
-    public virtual string Mode => this.Native != null ? OperatorRuntimeMode.Native : this.Docker != null ? OperatorRuntimeMode.Docker : this.Kubernetes != null ? OperatorRuntimeMode.Kubernetes : throw new Exception("The runtime mode must be set");
+    public virtual string Mode => this.Kubernetes != null ? OperatorRuntimeMode.Kubernetes : this.Native != null ? OperatorRuntimeMode.Native : this.Docker != null ? OperatorRuntimeMode.Docker : throw new Exception("The runtime mode must be set");
 
 }

--- a/src/operator/Synapse.Operator/appsettings.Development.json
+++ b/src/operator/Synapse.Operator/appsettings.Development.json
@@ -15,9 +15,12 @@
       "Uri": "http://localhost:5257"
     },
     "Runtime": {
-      "Native": {
-        "Directory":  "..\\..\\..\\..\\..\\runner\\Synapse.Runner\\bin\\Debug\\net9.0\\",
-        "Executable": "Synapse.Runner.exe"
+      //"Native": {
+      //  "Directory":  "..\\..\\..\\..\\..\\runner\\Synapse.Runner\\bin\\Debug\\net9.0\\",
+      //  "Executable": "Synapse.Runner.exe"
+      //}
+      "Kubernetes": {
+        "Namespace": "default"
       }
     }
   }


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the `WorkflowInstanceHandler` to ignore 304 errors when updating workflow instance status